### PR TITLE
Check for HTTPS support, and store the result in an option

### DIFF
--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -68,12 +68,10 @@ class WP_HTTPS_Detection {
 	 * Returns true if the URL has the scheme of HTTPS, and it has the correct token.
 	 * The token is only to verify that the request is for the same site.
 	 * Also, in wp_remote_get(), 'sslverify' is true by default.
-	 * This method is private, as it's not part of the public API to get HTTPS support.
-	 * Instead, please use get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ).
 	 *
 	 * @return boolean Whether HTTPS is supported.
 	 */
-	private function is_https_supported() {
+	public function is_https_supported() {
 		$request = wp_remote_get( add_query_arg(
 			self::REQUEST_TOKEN_QUERY_ARG,
 			$this->get_token(),

--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -46,7 +46,6 @@ class WP_HTTPS_Detection {
 		add_action( self::CRON_HOOK, array( $this, 'update_option_https_support' ) );
 		add_filter( 'cron_request', array( $this, 'ensure_http_if_sslverify' ), PHP_INT_MAX );
 		add_action( 'parse_query', array( $this, 'verify_https_check' ) );
-		add_action( 'init', array( $this, 'check_https_support' ) );
 	}
 
 	/**

--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -118,12 +118,8 @@ class WP_HTTPS_Detection {
 	 * @return array $request The filtered cron request arguments.
 	 */
 	public function ensure_http_if_sslverify( $request ) {
-		if ( 0 === strpos( $request['url'], 'https' ) ) {
-			if ( isset( $request['args'] ) ) {
-				$request['args']['sslverify'] = false;
-			} else {
-				$request['args'] = array( 'sslverify' => false );
-			}
+		if ( 0 === strpos( $request['url'], 'https://' ) ) {
+			$request['args']['sslverify'] = false;
 		}
 		return $request;
 	}

--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -46,6 +46,16 @@ class WP_HTTPS_Detection {
 		add_action( self::CRON_HOOK, array( $this, 'update_option_https_support' ) );
 		add_filter( 'cron_request', array( $this, 'ensure_http_if_sslverify' ), PHP_INT_MAX );
 		add_action( 'parse_query', array( $this, 'verify_https_check' ) );
+		add_action( 'init', array( $this, 'check_https_support' ) );
+	}
+
+	/**
+	 * Gets whether HTTPS is supported, using the stored result of the loopback request.
+	 *
+	 * @return boolean
+	 */
+	public static function is_https_supported() {
+		return (bool) get_option( self::HTTPS_SUPPORT_OPTION_NAME );
 	}
 
 	/**

--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -80,9 +80,11 @@ class WP_HTTPS_Detection {
 	/**
 	 * Makes a request to the home URL to determine whether HTTPS is supported.
 	 *
-	 * Returns true if the URL has the scheme of HTTPS, and it has the correct token.
-	 * The token is only to verify that the request is for the same site.
-	 * Also, in wp_remote_get(), 'sslverify' is true by default.
+	 * To ensure the request is from the correct origin,
+	 * this passes a query var of a random number to the request.
+	 * Then, the 'parse_query' hook verify_https_check() looks for the query var.
+	 * If it's present, it calls wp_die() with a hash of the query var.
+	 * This method then ensures that the hash is present in the response body,
 	 *
 	 * @return boolean|WP_Error Whether HTTPS is supported, or a WP_Error.
 	 */

--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * WP_HTTPS_Detection class.
+ *
+ * @package PWA
+ */
+
+/**
+ * WP_HTTPS_Detection class.
+ */
+class WP_HTTPS_Detection {
+
+	/**
+	 * The cron hook to check https support.
+	 *
+	 * @var string
+	 */
+	const CRON_HOOK = 'check_https_support';
+
+	/**
+	 * Option name for whether HTTPS is supported.
+	 *
+	 * @var string
+	 */
+	const HTTPS_SUPPORT_OPTION_NAME = 'is_https_supported';
+
+	/**
+	 * Secret for the https detection request.
+	 *
+	 * @var string
+	 */
+	const REQUEST_SECRET = 'https_detection_secret';
+
+	/**
+	 * Query arg key for the https detection token.
+	 *
+	 * @var string
+	 */
+	const REQUEST_TOKEN_QUERY_ARG = 'https_detection_token';
+
+	/**
+	 * Inits the class.
+	 */
+	public function init() {
+		add_action( 'wp', array( $this, 'schedule_cron' ) );
+		add_action( self::CRON_HOOK, array( $this, 'update_option_https_support' ) );
+	}
+
+	/**
+	 * Schedules a cron event to check for HTTPS support.
+	 */
+	public function schedule_cron() {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Makes a request to find whether HTTPS is supported, and stores the result in an option.
+	 */
+	public function update_option_https_support() {
+		update_option( self::HTTPS_SUPPORT_OPTION_NAME, $this->is_https_supported() );
+	}
+
+	/**
+	 * Makes a request to the home URL to determine whether HTTPS is supported.
+	 *
+	 * Returns true if the URL has the scheme of HTTPS, and it has the correct token.
+	 * The token is only to verify that the request is for the same site.
+	 * Also, in wp_remote_get(), 'sslverify' is true by default.
+	 * This method is private, as it's not part of the public API to get HTTPS support.
+	 * Instead, please use get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ).
+	 *
+	 * @return boolean Whether HTTPS is supported.
+	 */
+	private function is_https_supported() {
+		$request = wp_remote_get( add_query_arg(
+			self::REQUEST_TOKEN_QUERY_ARG,
+			$this->get_token(),
+			home_url( '/', 'http' )
+		) );
+
+		if ( is_wp_error( $request ) || ! method_exists( $request['http_response'], 'get_response_object' ) ) {
+			return false;
+		}
+
+		$response   = $request['http_response']->get_response_object();
+		$parsed_url = wp_parse_url( $response->url );
+		if ( ! $response->success || ! isset( $parsed_url['query'] ) ) {
+			return false;
+		}
+
+		$query_args = wp_parse_args( $parsed_url['query'] );
+		$is_https   = (
+			isset( $parsed_url['scheme'], $query_args[ self::REQUEST_TOKEN_QUERY_ARG ] )
+			&&
+			'https' === $parsed_url['scheme']
+			&&
+			$this->get_token() === $query_args[ self::REQUEST_TOKEN_QUERY_ARG ]
+		);
+
+		return $is_https;
+	}
+
+	/**
+	 * Gets the token, based on the secret.
+	 *
+	 * This token is not intended for security, as much as ensuring that the request is for this site.
+	 * By calling wp_hash(), it uses this site's salts, which should be different from other sites.
+	 *
+	 * @return string $token The token for the request.
+	 */
+	public function get_token() {
+		return wp_hash( self::REQUEST_SECRET );
+	}
+}

--- a/php/class-wp-https-detection.php
+++ b/php/class-wp-https-detection.php
@@ -32,7 +32,7 @@ class WP_HTTPS_Detection {
 	const REQUEST_SECRET = 'https_detection_secret';
 
 	/**
-	 * Query arg key for the https detection token.
+	 * Query arg key for the HTTPS detection token.
 	 *
 	 * @var string
 	 */
@@ -73,11 +73,19 @@ class WP_HTTPS_Detection {
 	 * @return boolean Whether HTTPS is supported.
 	 */
 	public function is_https_supported() {
-		$request = wp_remote_get( add_query_arg(
-			self::REQUEST_TOKEN_QUERY_ARG,
-			$this->get_token(),
-			home_url( '/', 'http' )
-		) );
+		$request = wp_remote_request(
+			add_query_arg(
+				self::REQUEST_TOKEN_QUERY_ARG,
+				$this->get_token(),
+				home_url( '/', 'http' )
+			),
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Cache-Control' => 'no-cache',
+				),
+			)
+		);
 
 		if ( is_wp_error( $request ) || ! method_exists( $request['http_response'], 'get_response_object' ) ) {
 			return false;
@@ -114,7 +122,7 @@ class WP_HTTPS_Detection {
 	}
 
 	/**
-	 * If the 'cron_request' arguments include a HTTPS URL, this ensures sslverify is false.
+	 * If the 'cron_request' arguments include an HTTPS URL, this ensures sslverify is false.
 	 *
 	 * Prevents an issue if HTTPS breaks,
 	 * where there would be a failed attempt to verify HTTPS.

--- a/pwa-wp.php
+++ b/pwa-wp.php
@@ -33,12 +33,15 @@ pwawp_init();
  */
 function pwawp_init() {
 	$classes = array(
-		'wp-web-app-manifest',
+		'web-app-manifest',
+		'https-detection',
 	);
 	foreach ( $classes as $class ) {
-		require PWAWP_PLUGIN_DIR . "/php/class-{$class}.php";
+		require PWAWP_PLUGIN_DIR . "/php/class-wp-{$class}.php";
 	}
 
 	$wp_web_app_manifest = new WP_Web_App_Manifest();
 	$wp_web_app_manifest->init();
+	$wp_https_detection = new WP_HTTPS_Detection();
+	$wp_https_detection->init();
 }

--- a/tests/test-class-wp-https-detection.php
+++ b/tests/test-class-wp-https-detection.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests for class WP_HTTPS_Detection.
+ *
+ * @package PWA
+ */
+
+/**
+ * Tests for class WP_HTTPS_Detection.
+ */
+class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
+
+	/**
+	 * Tested instance.
+	 *
+	 * @var WP_HTTPS_Detection
+	 */
+	public $instance;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new WP_HTTPS_Detection();
+	}
+
+	/**
+	 * Test init.
+	 *
+	 * @covers WP_HTTPS_Detection::init()
+	 */
+	public function test_init() {
+		$this->instance->init();
+		$this->assertEquals( 10, has_action( 'wp', array( $this->instance, 'schedule_cron' ) ) );
+		$this->assertEquals( 10, has_action( WP_HTTPS_Detection::CRON_HOOK, array( $this->instance, 'update_option_https_support' ) ) );
+	}
+
+	/**
+	 * Test schedule_cron.
+	 *
+	 * @covers WP_HTTPS_Detection::schedule_cron()
+	 */
+	public function test_schedule_cron() {
+		$this->assertFalse( wp_next_scheduled( WP_HTTPS_Detection::CRON_HOOK ) );
+
+		$this->instance->schedule_cron();
+		$this->assertNotFalse( wp_next_scheduled( WP_HTTPS_Detection::CRON_HOOK ) );
+
+		$cron_array       = _get_cron_array();
+		$https_check_cron = end( $cron_array );
+		$this->assertEquals(
+			array(
+				'args'     => array(),
+				'interval' => HOUR_IN_SECONDS,
+				'schedule' => 'hourly',
+			),
+			reset( $https_check_cron[ WP_HTTPS_Detection::CRON_HOOK ] )
+		);
+	}
+
+	/**
+	 * Test update_option_https_support.
+	 *
+	 * @covers WP_HTTPS_Detection::update_option_https_support()
+	 */
+	public function test_update_option_https_support() {
+		$this->instance->update_option_https_support();
+		$this->assertFalse( get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ) );
+
+		// There should be HTTPS support, as is_https_supported() should return true.
+		add_filter( 'http_response', array( $this, 'mock_correct_response' ) );
+		$this->instance->update_option_https_support();
+		$this->assertTrue( get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ) );
+		remove_filter( 'http_response', array( $this, 'mock_correct_response' ) );
+	}
+
+	/**
+	 * Test is_https_supported.
+	 *
+	 * @covers WP_HTTPS_Detection::is_https_supported()
+	 */
+	public function test_is_https_supported() {
+		$reflection    = new ReflectionObject( $this->instance );
+		$tested_method = $reflection->getMethod( 'is_https_supported' );
+		$tested_method->setAccessible( true );
+		$this->assertFalse( $tested_method->invoke( $this->instance ) );
+
+		// The response is HTTPS, but the token was not present.
+		add_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
+		$this->assertFalse( $tested_method->invoke( $this->instance ) );
+		remove_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
+
+		// The response is HTTPS with the token present, so is_https_supported() should return true.
+		add_filter( 'http_response', array( $this, 'mock_correct_response' ) );
+		$this->assertTrue( $tested_method->invoke( $this->instance ) );
+		remove_filter( 'http_response', array( $this, 'mock_correct_response' ) );
+	}
+
+	/**
+	 * Test get_token.
+	 *
+	 * @covers WP_HTTPS_Detection::get_token()
+	 */
+	public function test_get_token() {
+		$this->assertEquals( wp_hash( WP_HTTPS_Detection::REQUEST_SECRET ), $this->instance->get_token() );
+	}
+
+	/**
+	 * Alter the response to be HTTPS, but without the token.
+	 *
+	 * Still, this should not cause is_htts_supported() to return true.
+	 * It does not include the request token.
+	 *
+	 * @param WP_HTTP_Requests_Response $response The response object.
+	 * @return WP_HTTP_Requests_Response $response The filtered response object.
+	 */
+	public function mock_incorrect_response( $response ) {
+		$response['http_response']->get_response_object()->url = 'https://example.com';
+		return $response;
+	}
+
+	/**
+	 * Alter the response, which should cause is_https_supported() to return true because it includes the token.
+	 *
+	 * @param WP_HTTP_Requests_Response $response The response object.
+	 * @return WP_HTTP_Requests_Response $response The filtered response object.
+	 */
+	public function mock_correct_response( $response ) {
+		$response['http_response']->get_response_object()->url = add_query_arg(
+			WP_HTTPS_Detection::REQUEST_TOKEN_QUERY_ARG,
+			$this->instance->get_token(),
+			'https://example.com'
+		);
+		return $response;
+	}
+}

--- a/tests/test-class-wp-https-detection.php
+++ b/tests/test-class-wp-https-detection.php
@@ -83,19 +83,16 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 	 * @covers WP_HTTPS_Detection::is_https_supported()
 	 */
 	public function test_is_https_supported() {
-		$reflection    = new ReflectionObject( $this->instance );
-		$tested_method = $reflection->getMethod( 'is_https_supported' );
-		$tested_method->setAccessible( true );
-		$this->assertFalse( $tested_method->invoke( $this->instance ) );
+		$this->assertFalse( $this->instance->is_https_supported() );
 
 		// The response is HTTPS, but the token was not present.
 		add_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
-		$this->assertFalse( $tested_method->invoke( $this->instance ) );
+		$this->assertFalse( $this->instance->is_https_supported() );
 		remove_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
 
 		// The response is HTTPS with the token present, so is_https_supported() should return true.
 		add_filter( 'http_response', array( $this, 'mock_correct_response' ) );
-		$this->assertTrue( $tested_method->invoke( $this->instance ) );
+		$this->assertTrue( $this->instance->is_https_supported() );
 		remove_filter( 'http_response', array( $this, 'mock_correct_response' ) );
 	}
 

--- a/tests/test-class-wp-https-detection.php
+++ b/tests/test-class-wp-https-detection.php
@@ -50,6 +50,21 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_https_supported.
+	 *
+	 * @covers WP_HTTPS_Detection::is_https_supported()
+	 */
+	public function test_is_https_supported() {
+		$this->assertFalse( WP_HTTPS_Detection::is_https_supported() );
+
+		update_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME, true );
+		$this->assertTrue( WP_HTTPS_Detection::is_https_supported() );
+
+		update_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME, false );
+		$this->assertFalse( WP_HTTPS_Detection::is_https_supported() );
+	}
+
+	/**
 	 * Test schedule_cron.
 	 *
 	 * @covers WP_HTTPS_Detection::schedule_cron()

--- a/tests/test-pwa.php
+++ b/tests/test-pwa.php
@@ -26,5 +26,6 @@ class Test_PWA extends WP_UnitTestCase {
 	 */
 	public function test_pwawp_init() {
 		$this->assertTrue( class_exists( 'WP_Web_App_Manifest' ) );
+		$this->assertTrue( class_exists( 'WP_HTTPS_Detection' ) );
 	}
 }


### PR DESCRIPTION
**Request For Review**

Hi @westonruter,
Could you please review this PR, based on [your ideas](https://github.com/xwp/pwa-wp/issues/6#issue-326244070) in #6?

* Schedules a cron event to check for support.
* Makes an HTTP loopback request, and verifies that the response is HTTPS.
* Then, it stores this in an option.
* Instead of `is_ssl()`, you call `get_option( 'is_https_supported' )`

Closes #6.