### PR TITLE
Replace arbitrary service worker script scopes with just three: all, front, and admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build/
 composer.lock
+/vendor

--- a/tests/test-class-wp-service-workers.php
+++ b/tests/test-class-wp-service-workers.php
@@ -23,37 +23,199 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 	 * @inheritdoc
 	 */
 	public function setUp() {
+		global $wp_actions, $wp_default_service_workers;
 		parent::setUp();
-		$this->instance = new WP_Service_Workers();
+		unset( $wp_default_service_workers );
+		unset( $wp_actions['wp_default_service_workers'] );
+		$this->instance = wp_service_workers();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		unset( $GLOBALS['wp_service_workers'] );
 	}
 
 	/**
 	 * Test class constructor.
 	 *
 	 * @covers WP_Service_Workers::__construct()
+	 * @covers WP_Service_Workers::init()
+	 * @covers wp_service_workers()
 	 */
 	public function test_construct() {
-		$service_workers = new WP_Service_Workers();
-		$this->assertEquals( 'WP_Service_Workers', get_class( $service_workers ) );
+		global $wp_service_workers;
+		$this->assertEquals( 1, did_action( 'wp_default_service_workers' ) );
+		$this->assertSame( $wp_service_workers, $this->instance );
+		$this->assertInstanceOf( 'WP_Service_Workers', $this->instance );
+		$this->instance->init();
+
+		unset( $wp_service_workers );
+		wp_service_workers();
+		$this->assertEquals( 2, did_action( 'wp_default_service_workers' ) );
+		wp_service_workers();
+		$this->assertEquals( 2, did_action( 'wp_default_service_workers' ) );
+	}
+
+	/**
+	 * Get scripts.
+	 */
+	public function get_scripts() {
+		return array(
+			'default' => array(
+				'foo-all',
+				'/test-sw.js',
+				array( 'bar' ),
+				null,
+			),
+			'all'     => array(
+				'foo',
+				'/test-sw.js',
+				array(),
+				'all',
+			),
+			'front'   => array(
+				'foo',
+				'/test-sw.js',
+				array(),
+				'front',
+			),
+			'admin'   => array(
+				'foo',
+				'/test-sw.js',
+				array(),
+				'admin',
+			),
+		);
 	}
 
 	/**
 	 * Test adding new service worker.
 	 *
+	 * @param string $handle Handle.
+	 * @param string $src    Source.
+	 * @param array  $deps   Dependencies.
+	 * @param string $scope  Scope.
+	 * @dataProvider get_scripts
 	 * @covers WP_Service_Workers::add()
 	 */
-	public function test_register() {
-		$this->instance->register( 'foo', '/test-sw.js', array( 'bar' ) );
+	public function test_register( $handle, $src, $deps, $scope = null ) {
+		if ( $scope ) {
+			$this->instance->register( $handle, $src, $deps, $scope );
+		} else {
+			$this->instance->register( $handle, $src, $deps );
+		}
+		if ( ! $scope ) {
+			$scope = 'all';
+		}
+		$this->assertEquals( $scope, $this->instance->registered[ $handle ]->args['scope'] );
+		$this->assertArrayHasKey( $handle, $this->instance->registered );
+		$registered_sw = $this->instance->registered[ $handle ];
+		$this->assertEquals( $src, $registered_sw->src );
+		$this->assertEquals( $deps, $registered_sw->deps );
+	}
 
-		$default_scope = site_url( '/', 'relative' );
+	/**
+	 * Test using invalid scope.
+	 *
+	 * @expectedIncorrectUsage WP_Service_Workers::register
+	 */
+	public function test_register_invalid_scope() {
+		$this->instance->register( 'foo', '/test-sw.js', array( 'bar' ), 'bad' );
+		$this->assertEquals( 'all', $this->instance->registered['foo']->args['scope'] );
+	}
 
-		$this->assertTrue( in_array( $default_scope, $this->instance->get_scopes(), true ) );
-		$this->assertTrue( isset( $this->instance->registered['foo'] ) );
+	/**
+	 * Test serve_request.
+	 *
+	 * @covers WP_Service_Workers::serve_request()
+	 * @covers WP_Service_Workers::do_items()
+	 */
+	public function test_serve_request() {
+		wp_service_workers()->register( 'bar', array( $this, 'return_bar_sw' ), array( 'foo' ), 'front' );
+		wp_service_workers()->register( 'baz', array( $this, 'return_baz_sw' ), array( 'foo' ), 'admin' );
+		wp_service_workers()->register( 'foo', array( $this, 'return_foo_sw' ), array(), 'all' );
 
-		$registered_sw = $this->instance->registered['foo'];
+		ob_start();
+		wp_service_workers()->serve_request( 'bad' );
+		$this->assertContains( 'invalid_scope_requested', ob_get_clean() );
 
-		$this->assertEquals( '/test-sw.js', $registered_sw->src );
-		$this->assertTrue( in_array( $default_scope, $registered_sw->args['scopes'], true ) );
-		$this->assertEquals( array( 'bar' ), $registered_sw->deps );
+		ob_start();
+		wp_service_workers()->serve_request( 'front' );
+		$output = ob_get_clean();
+		$this->assertContains( $this->return_foo_sw(), $output );
+		$this->assertContains( $this->return_bar_sw(), $output );
+		$this->assertTrue(
+			strpos( $output, $this->return_foo_sw() ) < strpos( $output, $this->return_bar_sw() )
+		);
+
+		ob_start();
+		wp_service_workers()->serve_request( 'admin' );
+		$output = ob_get_clean();
+
+		$this->assertContains( $this->return_foo_sw(), $output );
+		$this->assertContains( $this->return_baz_sw(), $output );
+		$this->assertTrue(
+			strpos( $output, $this->return_foo_sw() ) < strpos( $output, $this->return_baz_sw() )
+		);
+	}
+
+	/**
+	 * Test serve_request for bad src callback.
+	 *
+	 * @expectedIncorrectUsage WP_Service_Workers::register
+	 * @covers WP_Service_Workers::serve_request()
+	 * @covers WP_Service_Workers::do_items()
+	 */
+	public function test_serve_request_bad_src_callback() {
+		wp_service_workers()->register( 'bar', array( 'Does_Not_Exist', 'return_bar_sw' ) );
+		ob_start();
+		wp_service_workers()->serve_request( 'admin' );
+		$output = ob_get_clean();
+		$this->assertContains( 'Service worker src is invalid', $output );
+	}
+
+	/**
+	 * Test serve_request bad src URL.
+	 *
+	 * @expectedIncorrectUsage WP_Service_Workers::register
+	 * @covers WP_Service_Workers::serve_request()
+	 * @covers WP_Service_Workers::do_items()
+	 */
+	public function test_serve_request_bad_src_url() {
+		wp_service_workers()->register( 'bar', '/food.png' );
+		ob_start();
+		wp_service_workers()->serve_request( 'front' );
+		$output = ob_get_clean();
+		$this->assertContains( 'Service worker src is invalid', $output );
+	}
+
+	/**
+	 * Get some JS code.
+	 *
+	 * @return string JS example code.
+	 */
+	public function return_foo_sw() {
+		return 'console.info("Hello Foo World");';
+	}
+
+	/**
+	 * Get some JS code.
+	 *
+	 * @return string JS example code.
+	 */
+	public function return_bar_sw() {
+		return 'console.info("Hello Bar World");';
+	}
+
+	/**
+	 * Get some JS code.
+	 *
+	 * @return string JS example code.
+	 */
+	public function return_baz_sw() {
+		return 'console.info("Hello Baz World");';
 	}
 }

--- a/tests/test-class-wp-service-workers.php
+++ b/tests/test-class-wp-service-workers.php
@@ -147,6 +147,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( $this->return_foo_sw(), $output );
 		$this->assertContains( $this->return_bar_sw(), $output );
+		$this->assertNotContains( $this->return_baz_sw(), $output );
 		$this->assertTrue(
 			strpos( $output, $this->return_foo_sw() ) < strpos( $output, $this->return_bar_sw() )
 		);
@@ -156,6 +157,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertContains( $this->return_foo_sw(), $output );
+		$this->assertNotContains( $this->return_bar_sw(), $output );
 		$this->assertContains( $this->return_baz_sw(), $output );
 		$this->assertTrue(
 			strpos( $output, $this->return_foo_sw() ) < strpos( $output, $this->return_baz_sw() )

--- a/tests/test-class-wp-service-workers.php
+++ b/tests/test-class-wp-service-workers.php
@@ -74,19 +74,19 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 				'foo',
 				'/test-sw.js',
 				array(),
-				'all',
+				WP_Service_Workers::SCOPE_ALL,
 			),
 			'front'   => array(
 				'foo',
 				'/test-sw.js',
 				array(),
-				'front',
+				WP_Service_Workers::SCOPE_FRONT,
 			),
 			'admin'   => array(
 				'foo',
 				'/test-sw.js',
 				array(),
-				'admin',
+				WP_Service_Workers::SCOPE_ADMIN,
 			),
 		);
 	}
@@ -108,7 +108,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 			$this->instance->register( $handle, $src, $deps );
 		}
 		if ( ! $scope ) {
-			$scope = 'all';
+			$scope = WP_Service_Workers::SCOPE_ALL;
 		}
 		$this->assertEquals( $scope, $this->instance->registered[ $handle ]->args['scope'] );
 		$this->assertArrayHasKey( $handle, $this->instance->registered );
@@ -124,7 +124,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 	 */
 	public function test_register_invalid_scope() {
 		$this->instance->register( 'foo', '/test-sw.js', array( 'bar' ), 'bad' );
-		$this->assertEquals( 'all', $this->instance->registered['foo']->args['scope'] );
+		$this->assertEquals( WP_Service_Workers::SCOPE_ALL, $this->instance->registered['foo']->args['scope'] );
 	}
 
 	/**
@@ -134,16 +134,16 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 	 * @covers WP_Service_Workers::do_items()
 	 */
 	public function test_serve_request() {
-		wp_service_workers()->register( 'bar', array( $this, 'return_bar_sw' ), array( 'foo' ), 'front' );
-		wp_service_workers()->register( 'baz', array( $this, 'return_baz_sw' ), array( 'foo' ), 'admin' );
-		wp_service_workers()->register( 'foo', array( $this, 'return_foo_sw' ), array(), 'all' );
+		wp_service_workers()->register( 'bar', array( $this, 'return_bar_sw' ), array( 'foo' ), WP_Service_Workers::SCOPE_FRONT );
+		wp_service_workers()->register( 'baz', array( $this, 'return_baz_sw' ), array( 'foo' ), WP_Service_Workers::SCOPE_ADMIN );
+		wp_service_workers()->register( 'foo', array( $this, 'return_foo_sw' ), array(), WP_Service_Workers::SCOPE_ALL );
 
 		ob_start();
 		wp_service_workers()->serve_request( 'bad' );
 		$this->assertContains( 'invalid_scope_requested', ob_get_clean() );
 
 		ob_start();
-		wp_service_workers()->serve_request( 'front' );
+		wp_service_workers()->serve_request( WP_Service_Workers::SCOPE_FRONT );
 		$output = ob_get_clean();
 		$this->assertContains( $this->return_foo_sw(), $output );
 		$this->assertContains( $this->return_bar_sw(), $output );
@@ -152,7 +152,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 		);
 
 		ob_start();
-		wp_service_workers()->serve_request( 'admin' );
+		wp_service_workers()->serve_request( WP_Service_Workers::SCOPE_ADMIN );
 		$output = ob_get_clean();
 
 		$this->assertContains( $this->return_foo_sw(), $output );
@@ -172,7 +172,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 	public function test_serve_request_bad_src_callback() {
 		wp_service_workers()->register( 'bar', array( 'Does_Not_Exist', 'return_bar_sw' ) );
 		ob_start();
-		wp_service_workers()->serve_request( 'admin' );
+		wp_service_workers()->serve_request( WP_Service_Workers::SCOPE_ADMIN );
 		$output = ob_get_clean();
 		$this->assertContains( 'Service worker src is invalid', $output );
 	}
@@ -187,7 +187,7 @@ class Test_WP_Service_Workers extends WP_UnitTestCase {
 	public function test_serve_request_bad_src_url() {
 		wp_service_workers()->register( 'bar', '/food.png' );
 		ob_start();
-		wp_service_workers()->serve_request( 'front' );
+		wp_service_workers()->serve_request( WP_Service_Workers::SCOPE_FRONT );
 		$output = ob_get_clean();
 		$this->assertContains( 'Service worker src is invalid', $output );
 	}

--- a/tests/test-pwa.php
+++ b/tests/test-pwa.php
@@ -6,26 +6,20 @@
  */
 
 /**
- * Tests for amp.php.
+ * Tests for pwa.php.
  */
 class Test_PWA extends WP_UnitTestCase {
 
 	/**
-	 * Test constants.
+	 * Test bootstrap.
 	 */
-	public function test_constants() {
+	public function test_bootstrap() {
 		$this->assertTrue( defined( 'PWAWP_VERSION' ) );
 		$this->assertTrue( defined( 'PWAWP_PLUGIN_FILE' ) );
 		$this->assertTrue( defined( 'PWAWP_PLUGIN_DIR' ) );
-	}
 
-	/**
-	 * Test pwawp_init().
-	 *
-	 * @covers pwawp_init()
-	 */
-	public function test_pwawp_init() {
 		$this->assertTrue( class_exists( 'WP_Web_App_Manifest' ) );
+		$this->assertTrue( class_exists( 'WP_Service_Workers' ) );
 		$this->assertTrue( class_exists( 'WP_HTTPS_Detection' ) );
 	}
 }

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -19,21 +19,21 @@ class WP_Service_Workers extends WP_Scripts {
 	/**
 	 * Scope for front.
 	 *
-	 * @var string
+	 * @var int
 	 */
 	const SCOPE_FRONT = 1;
 
 	/**
 	 * Scope for admin.
 	 *
-	 * @var string
+	 * @var int
 	 */
 	const SCOPE_ADMIN = 2;
 
 	/**
 	 * Scope for both front and admin.
 	 *
-	 * @var string
+	 * @var int
 	 */
 	const SCOPE_ALL = 3;
 
@@ -71,7 +71,7 @@ class WP_Service_Workers extends WP_Scripts {
 	 * @param string          $handle Name of the item. Should be unique.
 	 * @param string|callable $src    URL to the source in the WordPress install, or a callback that returns the JS to include in the service worker.
 	 * @param array           $deps   Optional. An array of registered item handles this item depends on. Default empty array.
-	 * @param string          $scope  Scope for which service worker the script will be part of. Can be WP_Service_Workers::SCOPE_FRONT, WP_Service_Workers::SCOPE_ADMIN, or WP_Service_Workers::SCOPE_ALL. Default to WP_Service_Workers::SCOPE_ALL.
+	 * @param int             $scope  Scope for which service worker the script will be part of. Can be WP_Service_Workers::SCOPE_FRONT, WP_Service_Workers::SCOPE_ADMIN, or WP_Service_Workers::SCOPE_ALL. Default to WP_Service_Workers::SCOPE_ALL.
 	 * @return bool Whether the item has been registered. True on success, false on failure.
 	 */
 	public function register( $handle, $src, $deps = array(), $scope = self::SCOPE_ALL ) {

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -86,18 +86,19 @@ class WP_Service_Workers extends WP_Scripts {
 	/**
 	 * Get service worker logic for scope.
 	 *
-	 * @param string $scope Scope of the Service Worker.
+	 * @see wp_service_worker_loaded()
+	 * @param int $scope Scope of the Service Worker.
 	 */
 	public function serve_request( $scope ) {
+		@header( 'Content-Type: text/javascript; charset=utf-8' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+
 		if ( self::SCOPE_FRONT !== $scope && self::SCOPE_ADMIN !== $scope ) {
 			status_header( 400 );
 			echo '/* invalid_scope_requested */';
 			return;
 		}
 
-		@header( 'Content-Type: text/javascript; charset=utf-8' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-
-		// @todo If $scope is 'admin' should this admin_enqueue_scripts, and if 'front' should it wp_enqueue_scripts?
+		// @todo If $scope is admin should this admin_enqueue_scripts, and if front should it wp_enqueue_scripts?
 		$scope_items = array();
 
 		// Get handles from the relevant scope only.

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -5,7 +5,8 @@
  * @package PWA
  */
 
-foreach ( array( 'wp_print_scripts', 'admin_print_scripts', 'customize_controls_print_scripts' ) as $filter ) {
+// Ensure service workers are printed on frontend, admin, Customizer, login, sign-up, and activate pages.
+foreach ( array( 'wp_print_scripts', 'admin_print_scripts', 'customize_controls_print_scripts', 'login_footer', 'after_signup_form', 'activate_wp_head' ) as $filter ) {
 	add_filter( $filter, 'wp_print_service_workers', 9 );
 }
 

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -2,7 +2,7 @@
 /**
  * Service Worker functions.
  *
- * @since ?
+ * @since 0.1
  *
  * @package PWA
  */
@@ -10,6 +10,7 @@
 /**
  * Initialize $wp_service_workers if it has not been set.
  *
+ * @since 0.1
  * @global WP_Service_Workers $wp_service_workers
  * @return WP_Service_Workers WP_Service_Workers instance.
  */
@@ -24,57 +25,71 @@ function wp_service_workers() {
 /**
  * Register a new service worker.
  *
- * @since ?
+ * @since 0.1
  *
  * @param string          $handle Name of the service worker. Should be unique.
  * @param string|callable $src    Callback method or relative path of the service worker.
  * @param array           $deps   Optional. An array of registered script handles this depends on. Default empty array.
- * @param array           $scopes Optional Scopes of the service worker.
+ * @param string          $scope  Scope for which service worker the script will be part of. Can be 'front', 'admin', or 'all'. Default to 'all'.
  * @return bool Whether the script has been registered. True on success, false on failure.
  */
-function wp_register_service_worker( $handle, $src, $deps = array(), $scopes = array() ) {
-	$service_workers = wp_service_workers();
-	$registered      = $service_workers->register( $handle, $src, $deps, $scopes );
-
-	return $registered;
+function wp_register_service_worker( $handle, $src, $deps = array(), $scope = 'all' ) {
+	return wp_service_workers()->register( $handle, $src, $deps, $scope );
 }
 
 /**
  * Get service worker URL by scope.
  *
- * @todo Use home_url() instead? See get_rest_url().
+ * @since 0.1
  *
- * @param string $scope Scope, for example 'wp-admin'. Defaults to '/'.
+ * @param string $scope Scope for which service worker the script will be part of. Can be 'front' or 'admin'. Default to 'front'.
  * @return string Service Worker URL.
  */
-function wp_get_service_worker_url( $scope = null ) {
-
-	if ( ! $scope ) {
-		$scope = site_url( '/', 'relative' );
+function wp_get_service_worker_url( $scope = 'front' ) {
+	if ( 'front' !== $scope && 'admin' !== $scope ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Scope must be either "front" or "admin".', 'pwa' ), '?' );
+		$scope = 'front';
 	}
 
 	return add_query_arg(
 		array( 'wp_service_worker' => $scope ),
-		site_url( '/', 'https' )
+		home_url( '/', 'https' )
 	);
 }
 
 /**
- * Print service workers' scripts.
+ * Print service workers' scripts that can be installed.
+ *
+ * @since 0.1
  */
 function wp_print_service_workers() {
+	global $pagenow;
+	$scopes = array();
 
-	$scopes = wp_service_workers()->get_scopes();
+	$on_front_domain = isset( $_SERVER['HTTP_HOST'] ) && wp_parse_url( home_url(), PHP_URL_HOST ) === $_SERVER['HTTP_HOST'];
+	$on_admin_domain = isset( $_SERVER['HTTP_HOST'] ) && wp_parse_url( admin_url(), PHP_URL_HOST ) === $_SERVER['HTTP_HOST'];
+
+	// Install the front service worker if currently on the home domain.
+	if ( $on_front_domain ) {
+		$scopes['front'] = home_url( '/', 'relative' ); // The home_url() here will account for subdirectory installs.
+	}
+
+	// Include admin service worker if it seems it will be used (and it can be installed).
+	if ( $on_admin_domain && ( is_user_logged_in() || is_admin() || in_array( $pagenow, array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ), true ) ) ) {
+		$scopes['admin'] = wp_parse_url( admin_url( '/' ), PHP_URL_PATH );
+	}
+
 	if ( empty( $scopes ) ) {
 		return;
 	}
+
 	?>
 	<script>
 		if ( navigator.serviceWorker ) {
 			window.addEventListener('load', function() {
-				<?php foreach ( $scopes as $scope ) { ?>
+				<?php foreach ( $scopes as $name => $scope ) { ?>
 					navigator.serviceWorker.register(
-						<?php echo wp_json_encode( wp_get_service_worker_url( $scope ) ); ?>,
+						<?php echo wp_json_encode( wp_get_service_worker_url( $name ) ); ?>,
 						<?php echo wp_json_encode( compact( 'scope' ) ); ?>
 					);
 				<?php } ?>
@@ -87,6 +102,7 @@ function wp_print_service_workers() {
 /**
  * Register query var.
  *
+ * @since 0.1
  * @param array $query_vars Query vars.
  * @return array Query vars.
  */
@@ -97,6 +113,9 @@ function wp_add_service_worker_query_var( $query_vars ) {
 
 /**
  * If it's a service worker script page, display that.
+ *
+ * @since 0.1
+ * @see rest_api_loaded()
  */
 function wp_service_worker_loaded() {
 	if ( ! empty( $GLOBALS['wp']->query_vars['wp_service_worker'] ) ) {

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -30,10 +30,10 @@ function wp_service_workers() {
  * @param string          $handle Name of the service worker. Should be unique.
  * @param string|callable $src    Callback method or relative path of the service worker.
  * @param array           $deps   Optional. An array of registered script handles this depends on. Default empty array.
- * @param string          $scope  Scope for which service worker the script will be part of. Can be 'front', 'admin', or 'all'. Default to 'all'.
+ * @param int             $scope  Scope for which service worker the script will be part of. Can be WP_Service_Workers::SCOPE_FRONT, WP_Service_Workers::SCOPE_ADMIN, or WP_Service_Workers::SCOPE_ALL. Default to WP_Service_Workers::SCOPE_ALL.
  * @return bool Whether the script has been registered. True on success, false on failure.
  */
-function wp_register_service_worker( $handle, $src, $deps = array(), $scope = 'all' ) {
+function wp_register_service_worker( $handle, $src, $deps = array(), $scope = WP_Service_Workers::SCOPE_ALL ) {
 	return wp_service_workers()->register( $handle, $src, $deps, $scope );
 }
 

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -42,13 +42,13 @@ function wp_register_service_worker( $handle, $src, $deps = array(), $scope = WP
  *
  * @since 0.1
  *
- * @param string $scope Scope for which service worker the script will be part of. Can be 'front' or 'admin'. Default to 'front'.
+ * @param int $scope Scope for which service worker to output. Can be WP_Service_Workers::SCOPE_FRONT (default) or WP_Service_Workers::SCOPE_ADMIN.
  * @return string Service Worker URL.
  */
-function wp_get_service_worker_url( $scope = 'front' ) {
-	if ( 'front' !== $scope && 'admin' !== $scope ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Scope must be either "front" or "admin".', 'pwa' ), '?' );
-		$scope = 'front';
+function wp_get_service_worker_url( $scope = WP_Service_Workers::SCOPE_FRONT ) {
+	if ( WP_Service_Workers::SCOPE_FRONT !== $scope && WP_Service_Workers::SCOPE_ADMIN !== $scope ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Scope must be either WP_Service_Workers::SCOPE_FRONT or WP_Service_Workers::SCOPE_ADMIN.', 'pwa' ), '?' );
+		$scope = WP_Service_Workers::SCOPE_FRONT;
 	}
 
 	return add_query_arg(
@@ -71,12 +71,12 @@ function wp_print_service_workers() {
 
 	// Install the front service worker if currently on the home domain.
 	if ( $on_front_domain ) {
-		$scopes['front'] = home_url( '/', 'relative' ); // The home_url() here will account for subdirectory installs.
+		$scopes[ WP_Service_Workers::SCOPE_FRONT ] = home_url( '/', 'relative' ); // The home_url() here will account for subdirectory installs.
 	}
 
 	// Include admin service worker if it seems it will be used (and it can be installed).
 	if ( $on_admin_domain && ( is_user_logged_in() || is_admin() || in_array( $pagenow, array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ), true ) ) ) {
-		$scopes['admin'] = wp_parse_url( admin_url( '/' ), PHP_URL_PATH );
+		$scopes[ WP_Service_Workers::SCOPE_ADMIN ] = wp_parse_url( admin_url( '/' ), PHP_URL_PATH );
 	}
 
 	if ( empty( $scopes ) ) {
@@ -118,8 +118,8 @@ function wp_add_service_worker_query_var( $query_vars ) {
  * @see rest_api_loaded()
  */
 function wp_service_worker_loaded() {
-	if ( ! empty( $GLOBALS['wp']->query_vars['wp_service_worker'] ) ) {
-		wp_service_workers()->serve_request( $GLOBALS['wp']->query_vars['wp_service_worker'] );
+	if ( isset( $GLOBALS['wp']->query_vars['wp_service_worker'] ) ) {
+		wp_service_workers()->serve_request( intval( $GLOBALS['wp']->query_vars['wp_service_worker'] ) );
 		exit;
 	}
 }


### PR DESCRIPTION
In #14 the ability was added for a service worker script to be registered with arbitrary scopes. This ability caused a problem (#26) whereby if a plugin registered a service worker script to an arbitrary scope and then that plugin was deactivated, that the service worker would be left installed indefinitely.

In reality, I believe only two distinct service workers would be relevant in a WordPress context: the frontend (`home_url('/')`) and the wp-admin (`admin_url('/')`). These are really the two separate environments in WordPress. On the frontend, all requests get routed by `WP_Rewrite` and loaded via `/index.php` and it makes sense that all service worker scripts used on the frontend should similarly get the corresponding `/` scope. A frontend service worker would likely be used to cache _frontend_ assets (such as for an app shell), which should be very different from how caching is handled in the admin. In the admin it would make sense for there to be scripts registered which are specific to the apps running in that context (e.g. Gutenberg) which would be needless to be included in the service worker on the frontend. Also, it is important to note that the frontend of a site and the WP admin can be served from different domains (e.g. `example.com` and `example.wordpress.com/wp-admin`) and so again, there is a natural differentiation between them. 

Because of this potential for differing front/admin domains, I think it is important for consistency to always have a service worker registered at `/` and another at `/wp-admin/`. Otherwise, it could be that a plugin registers a script to run at the `/` scope and would then expect it to run at `/wp-admin/` but when the the admin is accessed on a different, this wouldn't happen as expected: the service worker installed on the home origin would not be the same service worker installed when accessing the admin. A separate admin service worker would have to get installed anyway.

So I think we should always register a service worker at the `home_url( '/' )` scope for the frontend, and another service worker scope at `site_url( '/wp-admin/' )`. When the home and site URLs are the same, then the admin service worker could be installed when accessing the frontend, but we can limit this installation to only happen when the user is logged in; this installation can also happen when accessing the login screen so the admin service worker installs while logging in.

Finally, it should also be possible register a service worker script to run in both the front and admin contexts. For example in https://github.com/Automattic/amp-wp/pull/1261 I added a service worker to the AMP plugin to cache AMP CDN assets (e.g. so that they can be loaded while developing offline). Such a service worker logic is relevant to the frontend and wp-admin, and such a script a script can be registered with an `all` scope, instead of a `front` or `admin` scope.

# Usage

```php
// Register script to only run on the frontend, with dependency on some other app-shell SW script.
wp_register_service_worker(
    'foo', // Handle.
    plugin_dir_url( __FILE__ ) . 'foo.js', // Source.
    array( 'app-shell' ), // Dependency.
    WP_Service_Workers::SCOPE_FRONT // Scope.
);

// Register script (here via render callback instead of URL) to only run only in the admin.
wp_register_service_worker( 
    'bar', 
    function() { return 'console.info("Hello admin!")'; }, 
    array(), // No deps.
    WP_Service_Workers::SCOPE_ADMIN
);

// Register script with to run in both the frontend and wp-admin.
wp_register_service_worker( 'baz', plugin_dir_url( __FILE__ ) . 'baz.js', array(), WP_Service_Workers::SCOPE_ALL );

// The default values for $deps and $scope are array() and WP_Service_Workers::SCOPE_ALL  respectively, so this is same as previous.
wp_register_service_worker( 'baz', plugin_dir_url( __FILE__ ) . 'baz.js' );
```

# Changes

* Replace arbitrary scopes with just three: all, admin, and front.
* Install service workers on login screen and other non-front/admin screens
* Serve scripts registered to 'all' scope in service worker requests for both 'front' and 'admin'.
* When requesting service worker other than front/admin respond with 400 error.
* Remove no-cache header which conflicted with logic to handle not-modified responses.
* Improve comments in service worker before each script is printed, indicating handle and error.
* Let remove_url_scheme and get_validated_file_path methods be protected.
* Limit installation of service workers for front and admin based on whether they can be installed (on basis of current origin and whether user would access admin).

Closes #26. See #7.