### PR TITLE
Ensure ISO language code is used for manifest instead of WP locale

### DIFF
--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -139,7 +139,7 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 			'display'          => 'minimal-ui',
 			'name'             => get_bloginfo( 'name' ),
 			'short_name'       => $short_name_matches[0],
-			'lang'             => get_locale(),
+			'lang'             => get_bloginfo( 'language' ),
 			'dir'              => is_rtl() ? 'rtl' : 'ltr',
 			'start_url'        => get_home_url(),
 			'theme_color'      => WP_Web_App_Manifest::FALLBACK_THEME_COLOR,

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -99,9 +99,12 @@ class WP_Web_App_Manifest {
 			'name'      => get_bloginfo( 'name' ),
 			'start_url' => get_home_url(),
 			'display'   => 'minimal-ui',
-			'lang'      => get_locale(),
 			'dir'       => is_rtl() ? 'rtl' : 'ltr',
 		);
+		$language = get_bloginfo( 'language' );
+		if ( $language ) {
+			$manifest['lang'] = $language;
+		}
 
 		/**
 		 * Gets the 'short_name' by limiting the blog name to 12 characters.


### PR DESCRIPTION
Fixes `lang` so it is `en-US` instead of `en_US`.