### PR TITLE
Add Cache-Control: no-cache for service worker response

### DIFF
--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -90,6 +90,15 @@ class WP_Service_Workers extends WP_Scripts {
 	 * @param int $scope Scope of the Service Worker.
 	 */
 	public function serve_request( $scope ) {
+		/*
+		 * Per Workbox <https://developers.google.com/web/tools/workbox/guides/service-worker-checklist#cache-control_of_your_service_worker_file>:
+		 * "Generally, most developers will want to set the Cache-Control header to no-cache,
+		 * forcing browsers to always check the server for a new service worker file."
+		 * Nevertheless, an ETag header is also sent with support for Conditional Requests
+		 * to save on needlessly re-downloading the same service worker with each page load.
+		 */
+		@header( 'Cache-Control: no-cache' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+
 		@header( 'Content-Type: text/javascript; charset=utf-8' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 
 		if ( self::SCOPE_FRONT !== $scope && self::SCOPE_ADMIN !== $scope ) {
@@ -112,7 +121,7 @@ class WP_Service_Workers extends WP_Scripts {
 		$this->do_items( $scope_items );
 
 		$file_hash = md5( $this->output );
-		@header( "Etag: $file_hash" ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		@header( "ETag: $file_hash" ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 
 		$etag_header = isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) ? trim( $_SERVER['HTTP_IF_NONE_MATCH'] ) : false;
 		if ( $file_hash === $etag_header ) {


### PR DESCRIPTION
Per Workbox:

> When you register your service worker file, the browser will make a network request for the file. If your server returns a Cache-Control header with your service worker file, some browsers will cache your service worker file in the HTTP cache. Future requests for your service worker file will check the HTTP cache, which can cause some confusion while developing locally or after publishing a new service worker and changes don't seem to be taking effect.
>
> Generally, most developers will want to set the Cache-Control header to no-cache, forcing browsers to always check the server for a new service worker file.

See https://developers.google.com/web/tools/workbox/guides/service-worker-checklist#cache-control_of_your_service_worker_file

See also https://twitter.com/westonruter/status/1023793377886629889

