### PR TITLE
Ensure screen object is defined prior to accessing property

### DIFF
--- a/wp-includes/class-wp-offline-page-excluder.php
+++ b/wp-includes/class-wp-offline-page-excluder.php
@@ -121,7 +121,7 @@ class WP_Offline_Page_Excluder {
 		if ( $query->is_admin ) {
 			$screen = get_current_screen();
 
-			return ( 'nav-menus' === $screen->id );
+			return ( $screen && 'nav-menus' === $screen->id );
 		}
 
 		// Do no exclude when default offline page is requested.


### PR DESCRIPTION
Fixes issue I noticed in Gutenberg where PHP error log would report a PHP notice:

> Trying to get property of non-object