### PR TITLE
Conditionally redirect front-end requests to HTTPS

### DIFF
--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -304,7 +304,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$_SERVER['REQUEST_SCHEME'] = 'https';
 		$this->assertFalse( $this->did_redirect() );
 
-		// The request is for HTTPS, but the options to upgrade to HTTPS and whether HTTPS is supported aren't correct.
+		// The request is for HTTP, but the options to upgrade to HTTPS and whether HTTPS is supported aren't correct.
 		$home_url_http             = home_url( '/', 'http' );
 		$_SERVER['REQUEST_URI']    = $home_url_http;
 		$_SERVER['REQUEST_SCHEME'] = 'http';


### PR DESCRIPTION
**Request For Review**

Hi @hellofromtonya, could you please review this follow-up to #17?

Lighthouse reported that this does not redirect HTTP to HTTPS:
<img width="722" alt="redirect-to-https" src="https://user-images.githubusercontent.com/4063887/44682095-14c95800-aa08-11e8-8761-bb16c8b7d55a.png">

So this redirects to HTTPS:
* Only if the user has checked the 'Upgrade' checkbox, and the last loopback request to check HTTPS support succeeded.
* If `! is_admin()` , so if the SSL certificate expires somehow, admins won't be locked out of `/wp-admin`.


