### PR TITLE
Amend PR #54: https-redirect 

### DIFF
--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -305,9 +305,9 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$this->assertFalse( $this->did_redirect() );
 
 		// The request is for HTTP, but the options to upgrade to HTTPS and whether HTTPS is supported aren't correct.
-		$home_url_http             = home_url( '/', 'http' );
-		$_SERVER['HTTPS']          = '';
-		$_SERVER['REQUEST_URI']    = $home_url_http;
+		$home_url_http          = home_url( '/', 'http' );
+		$_SERVER['HTTPS']       = '';
+		$_SERVER['REQUEST_URI'] = $home_url_http;
 		$this->assertFalse( $this->did_redirect() );
 
 		// The checkbox to upgrade to HTTPS is checked, but the option for whether HTTPS is supported isn't correct.

--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -301,13 +301,13 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 	 */
 	public function test_conditionally_redirect_to_https() {
 		// If the request is for HTTPS, this should not redirect.
-		$_SERVER['REQUEST_SCHEME'] = 'https';
+		$_SERVER['HTTPS'] = 'on';
 		$this->assertFalse( $this->did_redirect() );
 
 		// The request is for HTTP, but the options to upgrade to HTTPS and whether HTTPS is supported aren't correct.
 		$home_url_http             = home_url( '/', 'http' );
+		$_SERVER['HTTPS']          = '';
 		$_SERVER['REQUEST_URI']    = $home_url_http;
-		$_SERVER['REQUEST_SCHEME'] = 'http';
 		$this->assertFalse( $this->did_redirect() );
 
 		// The checkbox to upgrade to HTTPS is checked, but the option for whether HTTPS is supported isn't correct.
@@ -317,6 +317,11 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		// The option for whether HTTPS is supported is now correct, so this should redirect.
 		update_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME, true );
 		$this->assertTrue( $this->did_redirect() );
+
+		// If is_ssl() is true, this should not redirect.
+		$_SERVER['HTTPS'] = 'on';
+		$this->assertFalse( $this->did_redirect() );
+		$_SERVER['HTTPS'] = '';
 
 		// If is_admin() is true, this should not redirect.
 		set_current_screen( 'edit.php' );

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -343,13 +343,15 @@ class WP_HTTPS_UI {
 	 */
 	public function conditionally_redirect_to_https() {
 		$do_redirect = (
-			isset( $_SERVER['REQUEST_SCHEME'], $_SERVER['REQUEST_URI'] ) && 'https' !== $_SERVER['REQUEST_SCHEME']
+			! is_ssl()
 			&&
 			! is_admin()
 			&&
 			get_option( self::UPGRADE_HTTPS_OPTION ) // The checkbox to upgrade to HTTPS is checked.
 			&&
 			get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ) // The last loopback request to check for HTTPS succeeded.
+			&&
+			isset( $_SERVER['REQUEST_URI'] )
 		);
 
 		if ( $do_redirect ) {


### PR DESCRIPTION
HI @westonruter,
This PR amends PR #54, based on your feedback.

Right now, it only uses `is_ssl()` instead of `$_SERVER['REQUEST_SCHEME']`. In case you'd like more changes, they could also go here.
