### PR TITLE
Rename WP_Service_Worker_Registry to WP_Service_Worker_Cache_Registry

### DIFF
--- a/pwa.php
+++ b/pwa.php
@@ -38,8 +38,8 @@ require_once PWA_PLUGIN_DIR . '/wp-includes/class-wp-https-ui.php';
 /** WP_Service_Workers Class */
 require_once PWA_PLUGIN_DIR . '/wp-includes/class-wp-service-workers.php';
 
-/** WP_Service_Worker_Registry Class */
-require_once PWA_PLUGIN_DIR . '/wp-includes/class-wp-service-worker-registry.php';
+/** WP_Service_Worker_Cache_Registry Class */
+require_once PWA_PLUGIN_DIR . '/wp-includes/class-wp-service-worker-cache-registry.php';
 
 /** WP_Service_Worker_Integration Interface */
 require_once PWA_PLUGIN_DIR . '/wp-includes/integrations/interface-wp-service-worker-integration.php';

--- a/tests/test-class-wp-service-worker-registry.php
+++ b/tests/test-class-wp-service-worker-registry.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Tests for class WP_Service_Worker_Registry.
+ * Tests for class WP_Service_Worker_Cache_Registry.
  *
  * @package PWA
  */
 
 /**
- * Tests for class WP_Service_Worker_Registry.
+ * Tests for class WP_Service_Worker_Cache_Registry.
  */
-class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
+class Test_WP_Service_Worker_Cache_Registry extends WP_UnitTestCase {
 
 	/**
 	 * Tested instance.
 	 *
-	 * @var WP_Service_Worker_Registry
+	 * @var WP_Service_Worker_Cache_Registry
 	 */
 	public $instance;
 
@@ -25,7 +25,7 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = new WP_Service_Worker_Registry();
+		$this->instance = new WP_Service_Worker_Cache_Registry();
 	}
 
 	/**
@@ -36,7 +36,7 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 	 * @param array  $strategy_args Optional. Strategy arguments. Default empty array.
 	 *
 	 * @dataProvider data_register_cached_route
-	 * @covers WP_Service_Worker_Registry::register_cached_route()
+	 * @covers WP_Service_Worker_Cache_Registry::register_cached_route()
 	 */
 	public function test_register_cached_route( $route, $strategy, $strategy_args = array() ) {
 		$this->instance->register_cached_route( $route, $strategy, $strategy_args );
@@ -63,21 +63,21 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 		return array(
 			array(
 				'/\.(?:js|css)$/',
-				WP_Service_Worker_Registry::STRATEGY_STALE_WHILE_REVALIDATE,
+				WP_Service_Worker_Cache_Registry::STRATEGY_STALE_WHILE_REVALIDATE,
 				array(
 					'cacheName' => 'static-resources',
 				),
 			),
 			array(
 				'/\.(?:png|gif|jpg|jpeg|svg)$/',
-				WP_Service_Worker_Registry::STRATEGY_CACHE_FIRST,
+				WP_Service_Worker_Cache_Registry::STRATEGY_CACHE_FIRST,
 				array(
 					'cacheName' => 'images',
 				),
 			),
 			array(
 				'https://hacker-news.firebaseio.com/v0/*',
-				WP_Service_Worker_Registry::STRATEGY_NETWORK_FIRST,
+				WP_Service_Worker_Cache_Registry::STRATEGY_NETWORK_FIRST,
 				array(
 					'networkTimeoutSeconds' => 3,
 					'cacheName'             => 'stories',
@@ -85,12 +85,12 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 			),
 			array(
 				'/.*(?:googleapis)\.com.*$/',
-				WP_Service_Worker_Registry::STRATEGY_NETWORK_ONLY,
+				WP_Service_Worker_Cache_Registry::STRATEGY_NETWORK_ONLY,
 				array(),
 			),
 			array(
 				'/.*(?:gstatic)\.com.*$/',
-				WP_Service_Worker_Registry::STRATEGY_CACHE_ONLY,
+				WP_Service_Worker_Cache_Registry::STRATEGY_CACHE_ONLY,
 				array(),
 			),
 		);
@@ -99,18 +99,18 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 	/**
 	 * Test registering a cached route with an invalid route.
 	 *
-	 * @covers WP_Service_Worker_Registry::register_cached_route()
-	 * @expectedIncorrectUsage WP_Service_Worker_Registry::register_cached_route
+	 * @covers WP_Service_Worker_Cache_Registry::register_cached_route()
+	 * @expectedIncorrectUsage WP_Service_Worker_Cache_Registry::register_cached_route
 	 */
 	public function test_register_cached_route_invalid_route() {
-		$this->instance->register_cached_route( 3, WP_Service_Worker_Registry::STRATEGY_STALE_WHILE_REVALIDATE );
+		$this->instance->register_cached_route( 3, WP_Service_Worker_Cache_Registry::STRATEGY_STALE_WHILE_REVALIDATE );
 	}
 
 	/**
 	 * Test registering a cached route with an invalid strategy.
 	 *
-	 * @covers WP_Service_Worker_Registry::register_cached_route()
-	 * @expectedIncorrectUsage WP_Service_Worker_Registry::register_cached_route
+	 * @covers WP_Service_Worker_Cache_Registry::register_cached_route()
+	 * @expectedIncorrectUsage WP_Service_Worker_Cache_Registry::register_cached_route
 	 */
 	public function test_register_cached_route_invalid_strategy() {
 		$this->instance->register_cached_route( '/\.(?:js|css)$/', 'invalid' );
@@ -123,7 +123,7 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 	 * @param array  $options Optional. Options. Default empty array.
 	 *
 	 * @dataProvider data_register_precached_route
-	 * @covers WP_Service_Worker_Registry::register_precached_route()
+	 * @covers WP_Service_Worker_Cache_Registry::register_precached_route()
 	 */
 	public function test_register_precached_route( $url, $options = array() ) {
 		$this->instance->register_precached_route( $url, $options );
@@ -133,7 +133,7 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 
 		$expected = array(
 			'revision' => null,
-			'cache'    => WP_Service_Worker_Registry::PRECACHE_CACHE_NAME,
+			'cache'    => WP_Service_Worker_Cache_Registry::PRECACHE_CACHE_NAME,
 		);
 		if ( ! is_array( $options ) ) {
 			$expected['revision'] = $options;
@@ -169,7 +169,7 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 			array(
 				'/assets/image.png',
 				array(
-					'cache' => WP_Service_Worker_Registry::RUNTIME_CACHE_NAME,
+					'cache' => WP_Service_Worker_Cache_Registry::RUNTIME_CACHE_NAME,
 				),
 			),
 			array(
@@ -182,13 +182,13 @@ class Test_WP_Service_Worker_Registry extends WP_UnitTestCase {
 	/**
 	 * Test registering a precached route with a revision outside of the precache.
 	 *
-	 * @covers WP_Service_Worker_Registry::register_precached_route()
-	 * @expectedIncorrectUsage WP_Service_Worker_Registry::register_precached_route
+	 * @covers WP_Service_Worker_Cache_Registry::register_precached_route()
+	 * @expectedIncorrectUsage WP_Service_Worker_Cache_Registry::register_precached_route
 	 */
 	public function test_register_precached_route_invalid_revision() {
 		$this->instance->register_precached_route( '/assets/style.css', array(
 			'revision' => '1.0.0',
-			'cache'    => WP_Service_Worker_Registry::RUNTIME_CACHE_NAME,
+			'cache'    => WP_Service_Worker_Cache_Registry::RUNTIME_CACHE_NAME,
 		) );
 	}
 }

--- a/wp-includes/class-wp-service-worker-cache-registry.php
+++ b/wp-includes/class-wp-service-worker-cache-registry.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP_Service_Worker_Registry class.
+ * WP_Service_Worker_Cache_Registry class.
  *
  * @package PWA
  */
@@ -10,7 +10,7 @@
  *
  * @since 0.2
  */
-class WP_Service_Worker_Registry {
+class WP_Service_Worker_Cache_Registry {
 
 	/**
 	 * Stale while revalidate caching strategy.
@@ -94,9 +94,9 @@ class WP_Service_Worker_Registry {
 	 * @since 0.2
 	 *
 	 * @param string $route    Route regular expression, without delimiters.
-	 * @param string $strategy Strategy, can be WP_Service_Worker_Registry::STRATEGY_STALE_WHILE_REVALIDATE, WP_Service_Worker_Registry::STRATEGY_CACHE_FIRST,
-	 *                         WP_Service_Worker_Registry::STRATEGY_NETWORK_FIRST, WP_Service_Worker_Registry::STRATEGY_CACHE_ONLY,
-	 *                         WP_Service_Worker_Registry::STRATEGY_NETWORK_ONLY.
+	 * @param string $strategy Strategy, can be WP_Service_Worker_Cache_Registry::STRATEGY_STALE_WHILE_REVALIDATE, WP_Service_Worker_Cache_Registry::STRATEGY_CACHE_FIRST,
+	 *                         WP_Service_Worker_Cache_Registry::STRATEGY_NETWORK_FIRST, WP_Service_Worker_Cache_Registry::STRATEGY_CACHE_ONLY,
+	 *                         WP_Service_Worker_Cache_Registry::STRATEGY_NETWORK_ONLY.
 	 * @param array  $strategy_args {
 	 *     An array of strategy arguments.
 	 *
@@ -158,7 +158,7 @@ class WP_Service_Worker_Registry {
 	 *
 	 * @since 0.2
 	 *
-	 * @see WP_Service_Worker_Registry::register_cached_route()
+	 * @see WP_Service_Worker_Cache_Registry::register_cached_route()
 	 * @link https://github.com/GoogleChrome/workbox/issues/1612
 	 *
 	 * @param string       $url URL to cache.
@@ -166,7 +166,7 @@ class WP_Service_Worker_Registry {
 	 *     Options. Or else if not an array, then treated as revision.
 	 *
 	 *     @type string $revision Revision. Currently only applicable for precache. Optional.
-	 *     @type string $cache    Cache. Defaults to the precache (WP_Service_Worker_Registry::PRECACHE_CACHE_NAME); the values 'precache' and 'runtime' will be replaced with the appropriately-namespaced cache names.
+	 *     @type string $cache    Cache. Defaults to the precache (WP_Service_Worker_Cache_Registry::PRECACHE_CACHE_NAME); the values 'precache' and 'runtime' will be replaced with the appropriately-namespaced cache names.
 	 * }
 	 */
 	public function register_precached_route( $url, $options = array() ) {

--- a/wp-includes/integrations/class-wp-service-worker-custom-background-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-custom-background-integration.php
@@ -17,9 +17,9 @@ class WP_Service_Worker_Custom_Background_Integration extends WP_Service_Worker_
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
 		if ( ! current_theme_supports( 'custom-background' ) || ! get_background_image() ) {
 			return;
 		}
@@ -30,6 +30,6 @@ class WP_Service_Worker_Custom_Background_Integration extends WP_Service_Worker_
 		if ( is_string( $file ) ) {
 			$revision = md5( file_get_contents( $file ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		}
-		$registry->register_precached_route( $url, $revision );
+		$cache_registry->register_precached_route( $url, $revision );
 	}
 }

--- a/wp-includes/integrations/class-wp-service-worker-custom-header-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-custom-header-integration.php
@@ -17,9 +17,9 @@ class WP_Service_Worker_Custom_Header_Integration extends WP_Service_Worker_Base
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
 		if ( ! current_theme_supports( 'custom-header' ) || ! get_custom_header() ) {
 			return;
 		}
@@ -49,7 +49,7 @@ class WP_Service_Worker_Custom_Header_Integration extends WP_Service_Worker_Base
 				if ( is_string( $file ) ) {
 					$revision = md5( file_get_contents( $file ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				}
-				$registry->register_precached_route( $url, $revision );
+				$cache_registry->register_precached_route( $url, $revision );
 			}
 			return;
 		}
@@ -59,7 +59,7 @@ class WP_Service_Worker_Custom_Header_Integration extends WP_Service_Worker_Base
 
 		if ( $attachment ) {
 			foreach ( $this->get_attachment_image_urls( $attachment->ID, array( $header->width, $header->height ) ) as $image_url ) {
-				$registry->register_precached_route( $image_url, $attachment->post_modified );
+				$cache_registry->register_precached_route( $image_url, $attachment->post_modified );
 			}
 		} elseif ( get_header_image() ) {
 			$url      = get_header_image();
@@ -68,7 +68,7 @@ class WP_Service_Worker_Custom_Header_Integration extends WP_Service_Worker_Base
 			if ( is_string( $file ) ) {
 				$revision = md5( file_get_contents( $file ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
-			$registry->register_precached_route( $url, $revision );
+			$cache_registry->register_precached_route( $url, $revision );
 		}
 	}
 }

--- a/wp-includes/integrations/class-wp-service-worker-custom-logo-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-custom-logo-integration.php
@@ -17,9 +17,9 @@ class WP_Service_Worker_Custom_Logo_Integration extends WP_Service_Worker_Base_I
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
 		if ( ! current_theme_supports( 'custom-logo' ) || ! get_theme_mod( 'custom_logo' ) ) {
 			return;
 		}
@@ -36,7 +36,7 @@ class WP_Service_Worker_Custom_Logo_Integration extends WP_Service_Worker_Base_I
 		}
 
 		foreach ( array_unique( $image_urls ) as $image_url ) {
-			$registry->register_precached_route( $image_url, $attachment->post_modified );
+			$cache_registry->register_precached_route( $image_url, $attachment->post_modified );
 		}
 	}
 }

--- a/wp-includes/integrations/class-wp-service-worker-fonts-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-fonts-integration.php
@@ -17,12 +17,12 @@ class WP_Service_Worker_Fonts_Integration extends WP_Service_Worker_Base_Integra
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
-		$registry->register_cached_route(
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
+		$cache_registry->register_cached_route(
 			'^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/(.*)',
-			WP_Service_Worker_Registry::STRATEGY_CACHE_FIRST,
+			WP_Service_Worker_Cache_Registry::STRATEGY_CACHE_FIRST,
 			array(
 				'cacheName' => 'googleapis',
 				'plugins'   => array(

--- a/wp-includes/integrations/class-wp-service-worker-scripts-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-scripts-integration.php
@@ -36,9 +36,9 @@ class WP_Service_Worker_Scripts_Integration extends WP_Service_Worker_Base_Integ
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
 		$handles = $this->handles;
 
 		if ( empty( $handles ) ) {
@@ -72,7 +72,7 @@ class WP_Service_Worker_Scripts_Integration extends WP_Service_Worker_Base_Integ
 			$url = apply_filters( 'script_loader_src', $url, $handle );
 
 			if ( $url ) {
-				$registry->register_precached_route( $url, $revision );
+				$cache_registry->register_precached_route( $url, $revision );
 			}
 		}
 		wp_scripts()->to_do = $original_to_do; // Restore original scripts to do.

--- a/wp-includes/integrations/class-wp-service-worker-site-icon-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-site-icon-integration.php
@@ -17,9 +17,9 @@ class WP_Service_Worker_Site_Icon_Integration extends WP_Service_Worker_Base_Int
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
 		if ( ! has_site_icon() || ! get_option( 'site_icon' ) ) {
 			return;
 		}
@@ -39,7 +39,7 @@ class WP_Service_Worker_Site_Icon_Integration extends WP_Service_Worker_Base_Int
 		) );
 
 		foreach ( $image_urls as $image_url ) {
-			$registry->register_precached_route( $image_url, $attachment->post_modified );
+			$cache_registry->register_precached_route( $image_url, $attachment->post_modified );
 		}
 	}
 }

--- a/wp-includes/integrations/class-wp-service-worker-styles-integration.php
+++ b/wp-includes/integrations/class-wp-service-worker-styles-integration.php
@@ -36,9 +36,9 @@ class WP_Service_Worker_Styles_Integration extends WP_Service_Worker_Base_Integr
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry ) {
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry ) {
 		$handles = $this->handles;
 
 		if ( empty( $handles ) ) {
@@ -72,7 +72,7 @@ class WP_Service_Worker_Styles_Integration extends WP_Service_Worker_Base_Integr
 			$url = apply_filters( 'style_loader_src', $url, $handle );
 
 			if ( $url ) {
-				$registry->register_precached_route( $url, $revision );
+				$cache_registry->register_precached_route( $url, $revision );
 			}
 		}
 		wp_styles()->to_do = $original_to_do; // Restore original styles to do.

--- a/wp-includes/integrations/interface-wp-service-worker-integration.php
+++ b/wp-includes/integrations/interface-wp-service-worker-integration.php
@@ -25,7 +25,7 @@ interface WP_Service_Worker_Integration {
 	 *
 	 * @since 0.2
 	 *
-	 * @param WP_Service_Worker_Registry $registry Instance to register service worker behavior with.
+	 * @param WP_Service_Worker_Cache_Registry $cache_registry Instance to register service worker behavior with.
 	 */
-	public function register( WP_Service_Worker_Registry $registry );
+	public function register( WP_Service_Worker_Cache_Registry $cache_registry );
 }


### PR DESCRIPTION
Per https://github.com/xwp/pwa-wp/pull/57#discussion_r215339110:

> It feels a bit confusing that there is `wp_service_workers()->register_script()` with its `wp_service_workers()->registered` array, but then there is _also_ `wp_service_workers()->registry` which is a `WP_Service_Worker_Registry` instance. If I didn't know better, this would confuse me a lot 😄 
>
> What do you think about renaming `WP_Service_Worker_Registry` to `WP_Service_Worker_Cache_Registry` and `$registry` to `$cache_registry`? That would seem to clear up the confusion because that registry is really about managing caching strategies and precaching.