### PR TITLE
Fix JSON-encoding of empty array as object

### DIFF
--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -456,7 +456,7 @@ class WP_Service_Workers extends WP_Scripts {
 			$exported_strategy_args[ $strategy_arg_name ] = $strategy_arg_value;
 		}
 
-		$script .= sprintf( 'const strategyArgs = %s;', $this->json_encode( $exported_strategy_args ) );
+		$script .= sprintf( 'const strategyArgs = %s;', empty( $exported_strategy_args ) ? '{}' : $this->json_encode( $exported_strategy_args ) );
 
 		if ( is_array( $plugins ) ) {
 


### PR DESCRIPTION
This was done elsewhere in:

https://github.com/xwp/pwa-wp/blob/57ebfa7652cd6e485056c7d11417acb726a7e87d/wp-includes/class-wp-service-workers.php#L483

So this ensures an empty `strategyArgs` is also output as `{}` instead of `[]`.