### PR TITLE
Undo the ability to use register_precached_route() for non-precache caches

### DIFF
--- a/tests/test-class-wp-service-worker-registry.php
+++ b/tests/test-class-wp-service-worker-registry.php
@@ -133,7 +133,6 @@ class Test_WP_Service_Worker_Cache_Registry extends WP_UnitTestCase {
 
 		$expected = array(
 			'revision' => null,
-			'cache'    => WP_Service_Worker_Cache_Registry::PRECACHE_CACHE_NAME,
 		);
 		if ( ! is_array( $options ) ) {
 			$expected['revision'] = $options;
@@ -167,12 +166,6 @@ class Test_WP_Service_Worker_Cache_Registry extends WP_UnitTestCase {
 				'1.0.0',
 			),
 			array(
-				'/assets/image.png',
-				array(
-					'cache' => WP_Service_Worker_Cache_Registry::RUNTIME_CACHE_NAME,
-				),
-			),
-			array(
 				'/assets/font.ttf',
 				array(),
 			),
@@ -180,7 +173,7 @@ class Test_WP_Service_Worker_Cache_Registry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test registering a precached route with a revision outside of the precache.
+	 * Test registering a precached route with an unrecognized option.
 	 *
 	 * @covers WP_Service_Worker_Cache_Registry::register_precached_route()
 	 * @expectedIncorrectUsage WP_Service_Worker_Cache_Registry::register_precached_route
@@ -188,7 +181,7 @@ class Test_WP_Service_Worker_Cache_Registry extends WP_UnitTestCase {
 	public function test_register_precached_route_invalid_revision() {
 		$this->instance->register_precached_route( '/assets/style.css', array(
 			'revision' => '1.0.0',
-			'cache'    => WP_Service_Worker_Cache_Registry::RUNTIME_CACHE_NAME,
+			'bogus'    => 'yes',
 		) );
 	}
 }

--- a/wp-includes/class-wp-service-worker-cache-registry.php
+++ b/wp-includes/class-wp-service-worker-cache-registry.php
@@ -151,22 +151,16 @@ class WP_Service_Worker_Cache_Registry {
 	/**
 	 * Register precached route.
 	 *
-	 * If a registered route is stored in the precache cache, then it will be served with the cache-first strategy.
-	 * For other routes registered with non-precached routes (e.g. runtime), you must currently also call
-	 * `wp_service_workers()->register_cached_route(...)` to specify the strategy for interacting with that
-	 * precached resource.
+	 * The routes registered here are served with the cache-first strategy.
 	 *
 	 * @since 0.2
-	 *
 	 * @see WP_Service_Worker_Cache_Registry::register_cached_route()
-	 * @link https://github.com/GoogleChrome/workbox/issues/1612
 	 *
 	 * @param string       $url URL to cache.
 	 * @param array|string $options {
-	 *     Options. Or else if not an array, then treated as revision.
+	 *     Options. If a string, then this is the revision.
 	 *
-	 *     @type string $revision Revision. Currently only applicable for precache. Optional.
-	 *     @type string $cache    Cache. Defaults to the precache (WP_Service_Worker_Cache_Registry::PRECACHE_CACHE_NAME); the values 'precache' and 'runtime' will be replaced with the appropriately-namespaced cache names.
+	 *     @type string $revision Revision. Optional.
 	 * }
 	 */
 	public function register_precached_route( $url, $options = array() ) {
@@ -176,17 +170,14 @@ class WP_Service_Worker_Cache_Registry {
 			);
 		}
 
-		$options = array_merge(
-			array(
-				'revision' => null,
-				'cache'    => self::PRECACHE_CACHE_NAME,
-			),
-			$options
+		$defaults = array(
+			'revision' => null,
 		);
 
-		if ( isset( $options['revision'] ) && self::PRECACHE_CACHE_NAME !== $options['cache'] ) {
-			unset( $options['revision'] );
-			_doing_it_wrong( __METHOD__, esc_html__( 'Specifying a revision for a URL to store in a non-precache cache is not currently supported.', 'pwa' ), '0.2' );
+		$options = array_merge( $defaults, $options );
+		foreach ( array_diff( array_keys( $options ), array_keys( $defaults ) ) as $unrecognized_key ) {
+			/* translators: %1$s is the unrecognized option key, %2$s is the precached route */
+			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'An unrecognized option "%1$s" was provided for a precached route %2$s.', 'pwa' ), $unrecognized_key, $url ) ), '0.2' );
 		}
 
 		$this->registered_precaching_routes[] = array_merge( $options, compact( 'url' ) );

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -239,6 +239,8 @@ class WP_Service_Workers extends WP_Scripts {
 
 		$script .= sprintf( "workbox.core.setCacheNameDetails( %s );\n", $this->json_encode( $cache_name_details ) );
 
+		// @todo Add filter controlling workbox.skipWaiting().
+		// @todo Add filter controlling workbox.clientsClaim().
 		/**
 		 * Filters whether navigation preload is enabled.
 		 *

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -195,7 +195,7 @@ class WP_Service_Workers extends WP_Scripts {
 			'BLACKLIST_PATTERNS' => $this->json_encode( $blacklist_patterns ),
 		);
 
-		$script = file_get_contents( PWA_PLUGIN_DIR . '/wp-includes/js/service-worker-error-response-handling.js' ); // phpcs:ignore
+		$script = file_get_contents( PWA_PLUGIN_DIR . '/wp-includes/js/service-worker-error-response-handling.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$script = preg_replace( '#/\*\s*global.+?\*/#', '', $script );
 
 		return str_replace(
@@ -410,11 +410,16 @@ class WP_Service_Workers extends WP_Scripts {
 	 * @return string Precaching logic.
 	 */
 	protected function get_precaching_for_routes_script() {
+		$precache_entries = $this->cache_registry->get_precached_routes();
+		if ( empty( $precache_entries ) ) {
+			return '';
+		}
+
 		$replacements = array(
-			'PRECACHE_ENTRIES' => $this->json_encode( $this->cache_registry->get_precached_routes() ),
+			'PRECACHE_ENTRIES' => $this->json_encode( $precache_entries ),
 		);
 
-		$script = file_get_contents( PWA_PLUGIN_DIR . '/wp-includes/js/service-worker-precaching.js' ); // phpcs:ignore
+		$script = file_get_contents( PWA_PLUGIN_DIR . '/wp-includes/js/service-worker-precaching.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$script = preg_replace( '#/\*\s*global.+?\*/#', '', $script );
 
 		return str_replace(

--- a/wp-includes/js/service-worker-precaching.js
+++ b/wp-includes/js/service-worker-precaching.js
@@ -1,27 +1,6 @@
 /* global PRECACHE_ENTRIES */
-
 {
-	const allEntries = PRECACHE_ENTRIES;
-	const precacheEntries = [];
-	const otherPrecacheEntries = {};
-
-	for ( const entry of allEntries ) {
-		if ( ! entry.cache || 'precache' === entry.cache || wp.serviceWorker.core.cacheNames.precache === entry.cache ) {
-			precacheEntries.push( {
-				url: entry.url,
-				revision: entry.revision || null
-			} );
-		} else {
-			if ( ! otherPrecacheEntries[ entry.cache ] ) {
-				otherPrecacheEntries[ entry.cache ] = new Set();
-			}
-			otherPrecacheEntries[ entry.cache ].add( entry.url );
-		}
-	}
-
-	if ( precacheEntries.length > 0 ) {
-		wp.serviceWorker.precaching.precache( precacheEntries );
-	}
+	wp.serviceWorker.precaching.precache( PRECACHE_ENTRIES );
 
 	// @todo Should not these parameters be specific to each entry as opposed to all entries?
 	// @todo Should not the strategy be tied to each entry as well?
@@ -31,18 +10,6 @@
 			/^utm_/,
 			/^ver$/
 		]
+		// @todo Add urlManipulation which allows for the list of ignoreUrlParametersMatching to be supplied with each entry.
 	} );
-
-	for ( let [ cacheName, urls ] of Object.entries( otherPrecacheEntries ) ) {
-		if ( 'runtime' === cacheName ) {
-			cacheName = wp.serviceWorker.core.cacheNames.runtime;
-		}
-		self.addEventListener( 'install', event => {
-			event.waitUntil(
-				caches.open( cacheName ).then(
-					cache => cache.addAll( urls.values() )
-				)
-			);
-		});
-	}
 }

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -122,7 +122,7 @@ function get_offline_template() {
  */
 function get_500_template() {
 	$templates = array(
-		'offline.php',
+		'500.php',
 		'error.php',
 	);
 


### PR DESCRIPTION
See https://github.com/GoogleChrome/workbox/issues/1612#issuecomment-419266411

Workbox isn't planning to extend its `precaching` module to allow for precaching assets in a cache other than the `precache` cache, and it won't be adding a caching strategy other than `cacheFirst` fir the precached routes.