### PR TITLE
Bump versions to 0.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.babelrc,.eslintrc,.jshintrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.md}]
+trim_trailing_whitespace = false

--- a/bin/verify-version-consistency.php
+++ b/bin/verify-version-consistency.php
@@ -19,10 +19,6 @@ if ( 'cli' !== php_sapi_name() ) {
 
 $versions = array();
 
-$versions['package.json']      = json_decode( file_get_contents( dirname( __FILE__ ) . '/../package.json' ) )->version;
-$versions['package-lock.json'] = json_decode( file_get_contents( dirname( __FILE__ ) . '/../package-lock.json' ) )->version;
-$versions['composer.json']     = json_decode( file_get_contents( dirname( __FILE__ ) . '/../composer.json' ) )->version;
-
 $readme_txt = file_get_contents( dirname( __FILE__ ) . '/../readme.txt' );
 if ( ! preg_match( '/Stable tag:\s+(?P<version>\S+)/i', $readme_txt, $matches ) ) {
 	echo "Could not find stable tag in readme\n";

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,15 @@
 {
-	"name": "xwp/pwa-wp",
-	"description": "WordPress plugin for adding PWA support.",
-	"homepage": "https://github.com/xwp/pwa-wp",
-	"type": "wordpress-plugin",
-	"license": "GPL-2.0",
-	"version": "0.1.0",
-	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-		"phpcompatibility/phpcompatibility-wp": "^1",
-		"wp-coding-standards/wpcs": "^1"
-	}
+  "name": "xwp/pwa-wp",
+  "description": "WordPress plugin for adding PWA support.",
+  "homepage": "https://github.com/xwp/pwa-wp",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0",
+  "require": {
+    "php": "^5.2.0 || ^7.0"
+  },
+  "require-dev": {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+    "phpcompatibility/phpcompatibility-wp": "^1",
+    "wp-coding-standards/wpcs": "^1"
+  }
 }

--- a/contributing.md
+++ b/contributing.md
@@ -55,7 +55,7 @@ When you push a commit to your PR, Travis CI will run the PHPUnit tests and snif
 Contributors who want to make a new release, follow these steps:
 
 1. Do `npm run build` and install the `pwa.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
-2. Bump plugin versions in `package.json` (×1), `package-lock.json` (×1, just do `npm install` first), `composer.json` (×1), and in `pwa.php` (×2: the metadata block in the header and also the `PWA_VERSION` constant).
+2. Bump plugin versions in `pwa.php` (×2: the metadata block in the header and also the `PWA_VERSION` constant), and the `Stable tag` in `readme.txt`.
 3. Add changelog entry to readme.
 4. Draft blog post about the new release, presumably on Make/Core.
 5. [Draft new release](https://github.com/xwp/pwa-wp/releases/new) on GitHub targeting the release branch, with the new plugin version as the tag and release title. Attaching the `pwa.zip` build to the release. Include link to changelog in release tag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
  "name": "pwa-wp",
- "version": "0.1.0",
  "lockfileVersion": 1,
  "requires": true,
  "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "type": "git",
   "url": "https://github.com/xwp/pwa-wp.git"
  },
- "version": "0.1.0",
  "license": "GPL-2.0+",
  "private": true,
  "devDependencies": {

--- a/pwa.php
+++ b/pwa.php
@@ -10,7 +10,7 @@
  * Plugin Name:       PWA
  * Plugin URI:        https://github.com/xwp/pwa-wp
  * Description:       Feature plugin to bring Progressive Web App (PWA) capabilities to Core
- * Version:           0.1.0
+ * Version:           0.2-alpha
  * Author:            XWP, Google, and contributors
  * Author URI:        https://github.com/xwp/pwa-wp/graphs/contributors
  * Text Domain:       pwa
@@ -21,7 +21,7 @@
  * Requires WP:       4.9
  */
 
-define( 'PWA_VERSION', '0.1.0' );
+define( 'PWA_VERSION', '0.2-alpha' );
 define( 'PWA_PLUGIN_FILE', __FILE__ );
 define( 'PWA_PLUGIN_DIR', dirname( __FILE__ ) );
 define( 'PWA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -583,6 +583,8 @@ class WP_Service_Workers extends WP_Scripts {
 			return;
 		}
 
+		printf( "/* PWA v%s */\n\n", esc_html( PWA_VERSION ) );
+
 		$this->output  = '';
 		$this->output .= $this->get_base_script();
 		$this->output .= $this->get_error_response_handling_script();


### PR DESCRIPTION
* Include plugin version in service worker.
* Add `.editorconfig`.
* Remove unnecessary versions.

See:

* https://github.com/Automattic/amp-wp/pull/1405
* https://github.com/Automattic/amp-wp/pull/1336
* https://github.com/Automattic/amp-wp/pull/1334
* https://github.com/Automattic/amp-wp/pull/1333