### PR TITLE
Improve handling of offline/500 error templates based on user's authenticated state

### DIFF
--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -36,4 +36,4 @@ function pwa_parse_query_for_error_template( WP_Query $query ) {
 			break;
 	}
 }
-add_action( 'parse_query', 'pwa_parse_query_for_error_template' );
+add_action( 'parse_query', 'pwa_parse_query_for_error_template', 1 );

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -115,17 +115,20 @@ class WP_Service_Workers extends WP_Scripts {
 			$revision .= sprintf( ';%s-v%s', $stylesheet, wp_get_theme( $stylesheet )->Version );
 		}
 
+		// Ensure the user-specific offline/500 pages are precached, and thet they update when user logs out or switches to another user.
+		$revision .= sprintf( ';user-%d', get_current_user_id() );
+
 		$scope = $this->get_current_scope();
 		if ( self::SCOPE_FRONT === $scope ) {
 			$offline_error_template_file  = pwa_locate_template( array( 'offline.php', 'error.php' ) );
 			$offline_error_precache_entry = array(
 				'url'      => add_query_arg( 'wp_error_template', 'offline', home_url( '/' ) ),
-				'revision' => $revision . '-' . md5( $offline_error_template_file . file_get_contents( $offline_error_template_file ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				'revision' => $revision . ';' . md5( $offline_error_template_file . file_get_contents( $offline_error_template_file ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			);
 			$server_error_template_file   = pwa_locate_template( array( '500.php', 'error.php' ) );
 			$server_error_precache_entry  = array(
 				'url'      => add_query_arg( 'wp_error_template', '500', home_url( '/' ) ),
-				'revision' => $revision . '-' . md5( $server_error_template_file . file_get_contents( $server_error_template_file ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				'revision' => $revision . ';' . md5( $server_error_template_file . file_get_contents( $server_error_template_file ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			);
 
 			/**

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -13,6 +13,7 @@ foreach ( array( 'wp_print_scripts', 'admin_print_scripts', 'customize_controls_
 }
 
 add_action( 'parse_query', 'wp_service_worker_loaded' );
+add_action( 'parse_query', 'wp_hide_admin_bar_offline' );
 
 add_action( 'wp_head', 'wp_add_error_template_no_robots' );
 add_action( 'error_head', 'wp_add_error_template_no_robots' );

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -101,6 +101,17 @@ function wp_add_error_template_no_robots() {
 }
 
 /**
+ * Hide the admin bar if serving the offline template.
+ *
+ * @since 0.2
+ */
+function wp_hide_admin_bar_offline() {
+	if ( is_offline() ) {
+		show_admin_bar( false );
+	}
+}
+
+/**
  * Filter the document title for the offline/500 error template.
  *
  * In core merge, this would amend `wp_get_document_title()`.


### PR DESCRIPTION
- Include current user ID in the `revision` for the offline and 500 page URLs so that the precached pages will update based on the user's authenticated state.
- Prevent admin bar from ever showing on offline pages. This is complimentary to a theme's `offline.php` template also doing `add_filter( 'has_nav_menu', '__return_false' )` to prevent showing nav menus (since presumably all such links will not work).

Fixes #63.