### PR TITLE
Improve HTTPS detection and opt-in

### DIFF
--- a/tests/test-class-wp-https-detection.php
+++ b/tests/test-class-wp-https-detection.php
@@ -63,7 +63,6 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 	 * @covers WP_HTTPS_Detection::init()
 	 */
 	public function test_init() {
-		$this->assertEquals( 10, has_action( 'wp', array( $this->instance, 'schedule_cron' ) ) );
 		$this->assertEquals( 10, has_action( WP_HTTPS_Detection::CRON_HOOK, array( $this->instance, 'update_https_support_options' ) ) );
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'cron_request', array( $this->instance, 'conditionally_prevent_sslverify' ) ) );
 	}
@@ -128,17 +127,6 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 	 * @covers WP_HTTPS_Detection::schedule_cron()
 	 */
 	public function test_schedule_cron() {
-		// If is_currently_https() is true, this should not schedule the cron event, as there is no need to check for HTTPS.
-		update_option( 'siteurl', self::HTTPS_URL );
-		update_option( 'home', self::HTTPS_URL );
-		add_filter( 'set_url_scheme', array( $this, 'convert_to_https' ) );
-		$this->instance->schedule_cron();
-		$this->assertFalse( wp_get_schedule( WP_HTTPS_Detection::CRON_HOOK ) );
-
-		// If is_currently_https() is false, this should schedule the cron event.
-		remove_filter( 'set_url_scheme', array( $this, 'convert_to_https' ) );
-		update_option( 'siteurl', self::HTTP_URL );
-		update_option( 'home', self::HTTP_URL );
 		$this->instance->schedule_cron();
 		$this->assertEquals( WP_HTTPS_Detection::CRON_INTERVAL, wp_get_schedule( WP_HTTPS_Detection::CRON_HOOK ) );
 

--- a/tests/test-class-wp-https-detection.php
+++ b/tests/test-class-wp-https-detection.php
@@ -82,7 +82,7 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 				$insecure_img_src
 			)
 		);
-		$this->assertEquals( array( $insecure_img_src ), $this->instance->get_insecure_content( compact( 'body' ) ) );
+		$this->assertEquals( array( $insecure_img_src ), $this->instance->get_insecure_content( $body ) );
 
 		$insecure_audio_src = 'http://example.com/foo';
 		$insecure_video_src = 'http://example.com/bar';
@@ -96,7 +96,7 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 		);
 		$this->assertEmpty( array_diff(
 			array( $insecure_audio_src, $insecure_video_src ),
-			$this->instance->get_insecure_content( compact( 'body' ) )
+			$this->instance->get_insecure_content( $body )
 		) );
 
 		// Allow interpolating tags into the <head>.
@@ -117,7 +117,7 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 		);
 		$this->assertEmpty( array_diff(
 			array( $insecure_audio_src, $insecure_script_src, $insecure_link_href ),
-			$this->instance->get_insecure_content( compact( 'body' ) )
+			$this->instance->get_insecure_content( $body )
 		) );
 	}
 
@@ -170,16 +170,39 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 		 * And because the request failed, it should not update the insecure content option.
 		 */
 		$this->instance->update_https_support_options();
-		$this->assertFalse( get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ) );
+		$support = get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME );
+		$this->assertInstanceOf( 'WP_Error', $support );
+		$this->assertArrayHasKey( 'response_error', $support->errors );
 		$this->assertEmpty( get_option( WP_HTTPS_Detection::INSECURE_CONTENT_OPTION_NAME ) );
 		remove_filter( 'http_response', array( $this, 'mock_error_response' ) );
 
 		// The response is a 301, so the option value should be false.
 		add_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
 		$this->instance->update_https_support_options();
-		$this->assertFalse( get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ) );
+		$support = get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME );
+		$this->assertInstanceOf( 'WP_Error', $support );
+		$this->assertArrayHasKey( 'response_error', $support->errors );
 		$this->assertEmpty( get_option( WP_HTTPS_Detection::INSECURE_CONTENT_OPTION_NAME ) );
 		remove_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
+
+		add_filter( 'http_response', array( $this, 'mock_successful_response' ) );
+		$this->instance->update_https_support_options();
+		$this->assertTrue( get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME ) );
+		remove_filter( 'http_response', array( $this, 'mock_successful_response' ) );
+
+		// The response should have a code of 301.
+		add_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
+		$this->instance->update_https_support_options();
+		$support = get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME );
+		$this->assertInstanceOf( 'WP_Error', $support );
+		remove_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
+
+		add_filter( 'http_response', array( $this, 'mock_response_incorrect_manifest' ) );
+		$this->instance->update_https_support_options();
+		$support = get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME );
+		$this->assertInstanceOf( 'WP_Error', $support );
+		$this->assertEquals( 'invalid_https_validation_source', $support->get_error_code() );
+		remove_filter( 'http_response', array( $this, 'mock_response_incorrect_manifest' ) );
 	}
 
 	/**
@@ -202,32 +225,6 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 		update_option( 'home', self::HTTPS_URL );
 		add_filter( 'set_url_scheme', array( $this, 'convert_to_https' ) );
 		$this->assertTrue( $this->instance->is_currently_https() );
-	}
-
-	/**
-	 * Test check_https_support.
-	 *
-	 * @covers WP_HTTPS_Detection::check_https_support()
-	 */
-	public function test_check_https_support() {
-		add_filter( 'http_response', array( $this, 'mock_successful_response' ) );
-		$https_support = $this->instance->check_https_support();
-		$this->assertEquals(
-			array( 'code' => 200 ),
-			$https_support['response']
-		);
-		$this->assertContains( '<link rel="manifest"', $https_support['body'] );
-
-		// The response should have a code of 301.
-		add_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
-		$https_support = $this->instance->check_https_support();
-		$this->assertEquals( array( 'code' => self::MOCK_INCORRECT_RESPONSE_CODE ), $https_support['response'] );
-		remove_filter( 'http_response', array( $this, 'mock_incorrect_response' ) );
-
-		add_filter( 'http_response', array( $this, 'mock_response_incorrect_manifest' ) );
-		$this->assertTrue( is_wp_error( $this->instance->check_https_support() ) );
-		remove_filter( 'http_response', array( $this, 'mock_response_incorrect_manifest' ) );
-
 	}
 
 	/**

--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -75,7 +75,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'admin_init', array( $this->instance, 'init_admin' ) ) );
 		$this->assertEquals( 10, has_action( 'init', array( $this->instance, 'filter_site_url_and_home' ) ) );
 		$this->assertEquals( 10, has_action( 'init', array( $this->instance, 'filter_header' ) ) );
-		$this->assertEquals( 10, has_action( 'wp_loaded', array( $this->instance, 'conditionally_redirect_to_https' ) ) );
+		$this->assertEquals( 10, has_action( 'template_redirect', array( $this->instance, 'conditionally_redirect_to_https' ) ) );
 	}
 
 	/**
@@ -300,10 +300,6 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$_SERVER['HTTPS'] = 'on';
 		$this->assertFalse( $this->did_redirect() );
 		$_SERVER['HTTPS'] = '';
-
-		// If is_admin() is true, this should not redirect.
-		set_current_screen( 'edit.php' );
-		$this->assertFalse( $this->did_redirect() );
 	}
 
 	/**

--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -135,6 +135,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 	 */
 	public function test_render_https_settings() {
 		// Set the option value, which should appear in the <input type="checkbox"> elements.
+		update_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME, true );
 		update_option( WP_HTTPS_UI::UPGRADE_HTTPS_OPTION, WP_HTTPS_UI::OPTION_CHECKED_VALUE );
 		update_option( 'siteurl', self::HTTPS_URL );
 		update_option( 'home', self::HTTPS_URL );

--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -87,7 +87,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		global $new_whitelist_options, $wp_registered_settings;
 
 		$base_expected_settings = array(
-			'type'         => 'string',
+			'type'         => 'boolean',
 			'group'        => WP_HTTPS_UI::OPTION_GROUP,
 			'description'  => '',
 			'show_in_rest' => false,
@@ -96,7 +96,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$expected_https_settings = array_merge(
 			$base_expected_settings,
 			array(
-				'sanitize_callback' => array( $this->instance, 'upgrade_https_sanitize_callback' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
 			)
 		);
 		$this->instance->register_settings();
@@ -105,28 +105,6 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 			$expected_https_settings,
 			$wp_registered_settings[ WP_HTTPS_UI::UPGRADE_HTTPS_OPTION ]
 		);
-	}
-
-	/**
-	 * Test upgrade_https_sanitize_callback.
-	 *
-	 * @covers WP_HTTPS_UI::upgrade_https_sanitize_callback()
-	 */
-	public function test_upgrade_https_sanitize_callback() {
-		/**
-		 * Test the <input type="checkbox"> being checked.
-		 * This callback does not evaluate the argument, so it could be anything.
-		 */
-		$_POST[ WP_HTTPS_UI::UPGRADE_HTTPS_OPTION ] = WP_HTTPS_UI::OPTION_CHECKED_VALUE;
-		$this->assertTrue( $this->instance->upgrade_https_sanitize_callback( 'foo' ) );
-
-		// The checkbox value could be anything, as long as the $_POST value isset().
-		$_POST[ WP_HTTPS_UI::UPGRADE_HTTPS_OPTION ] = 'baz';
-		$this->assertTrue( $this->instance->upgrade_https_sanitize_callback( 'bar' ) );
-
-		// If the $_POST value is not set, the callback should return false.
-		unset( $_POST[ WP_HTTPS_UI::UPGRADE_HTTPS_OPTION ] );
-		$this->assertFalse( $this->instance->upgrade_https_sanitize_callback( 'baz' ) );
 	}
 
 	/**

--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -130,14 +130,16 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 	 */
 	public function test_get_manifest() {
 		$this->mock_site_icon();
+		$blogname = "PWA's Domain Is Here";
+		update_option( 'blogname', $blogname );
 		$actual_manifest = $this->instance->get_manifest();
 
-		preg_match( '/^.{0,12}(?= |$)/', get_bloginfo( 'name' ), $short_name_matches );
+		preg_match( '/^.{0,12}(?= |$)/', $blogname, $short_name_matches );
 		$expected_manifest = array(
 			'background_color' => WP_Web_App_Manifest::FALLBACK_THEME_COLOR,
 			'description'      => get_bloginfo( 'description' ),
 			'display'          => 'minimal-ui',
-			'name'             => get_bloginfo( 'name' ),
+			'name'             => $blogname,
 			'short_name'       => $short_name_matches[0],
 			'lang'             => get_bloginfo( 'language' ),
 			'dir'              => is_rtl() ? 'rtl' : 'ltr',

--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -57,7 +57,7 @@ class WP_HTTPS_Detection {
 	 * Initializes the object.
 	 */
 	public function init() {
-		add_action( 'wp', array( $this, 'schedule_cron' ) );
+		self::schedule_cron();
 		add_action( self::CRON_HOOK, array( $this, 'update_https_support_options' ) );
 		add_filter( 'cron_request', array( $this, 'conditionally_prevent_sslverify' ), PHP_INT_MAX );
 
@@ -69,7 +69,7 @@ class WP_HTTPS_Detection {
 	 * Schedules a cron event to check for HTTPS support.
 	 */
 	public function schedule_cron() {
-		if ( ! wp_next_scheduled( self::CRON_HOOK ) && ! $this->is_currently_https() ) {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
 			wp_schedule_event( time(), self::CRON_INTERVAL, self::CRON_HOOK );
 		}
 	}

--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -81,21 +81,62 @@ class WP_HTTPS_Detection {
 	 * But if the request is a WP_Error, this does not update the option for insecure content.
 	 */
 	public function update_https_support_options() {
-		if ( $this->is_currently_https() ) {
-			return;
-		}
+		$support_errors = new WP_Error();
 
-		$https_support_response = $this->check_https_support();
-		update_option(
-			self::HTTPS_SUPPORT_OPTION_NAME,
-			! is_wp_error( $https_support_response ) && 200 === wp_remote_retrieve_response_code( $https_support_response )
+		$response = wp_remote_request(
+			home_url( '/', 'https' ),
+			array(
+				'headers'   => array(
+					'Cache-Control' => 'no-cache',
+				),
+				'sslverify' => true,
+			)
 		);
 
-		if ( ! is_wp_error( $https_support_response ) ) {
-			$insecure_content = $this->get_insecure_content( $https_support_response );
-			if ( ! is_wp_error( $insecure_content ) ) {
-				update_option( self::INSECURE_CONTENT_OPTION_NAME, $insecure_content );
+		if ( is_wp_error( $response ) ) {
+			$unverified_response = wp_remote_request(
+				home_url( '/', 'https' ),
+				array(
+					'headers'   => array(
+						'Cache-Control' => 'no-cache',
+					),
+					'sslverify' => false,
+				)
+			);
+
+			if ( is_wp_error( $unverified_response ) ) {
+				$support_errors->errors = array_merge( $unverified_response->errors );
+			} else {
+				$support_errors->add(
+					'ssl_verification_failed',
+					$response->get_error_message()
+				);
 			}
+			$response = $unverified_response;
+		}
+
+		$body = null;
+		if ( ! is_wp_error( $response ) ) {
+			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				$support_errors->add( 'response_error', wp_remote_retrieve_response_message( $response ) );
+			} else {
+				$body = wp_remote_retrieve_body( $response );
+				if ( ! $this->has_proper_manifest( $body ) ) {
+					$support_errors->add(
+						'invalid_https_validation_source',
+						__( 'There was an issue in the request for HTTPS verification.', 'pwa' )
+					);
+				}
+			}
+		}
+
+		update_option(
+			self::HTTPS_SUPPORT_OPTION_NAME,
+			empty( $support_errors->errors ) ? true : $support_errors
+		);
+
+		if ( $body ) {
+			update_option( self::INSECURE_CONTENT_OPTION_NAME, $this->get_insecure_content( $body ) );
 		}
 	}
 
@@ -115,37 +156,6 @@ class WP_HTTPS_Detection {
 			}
 		}
 		return true;
-	}
-
-	/**
-	 * Makes a loopback request to the homepage to determine whether HTTPS is supported.
-	 *
-	 * @return array|WP_Error A response from a loopback request to the homepage, or a WP_Error.
-	 */
-	public function check_https_support() {
-		$response = wp_remote_request(
-			home_url( '/', 'https' ),
-			array(
-				'headers' => array(
-					'Cache-Control' => 'no-cache',
-				),
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-
-		if ( ! $this->has_proper_manifest( $body ) ) {
-			return new WP_Error(
-				'invalid_https_validation_source',
-				__( 'There was an issue in the request for HTTPS verification.', 'pwa' )
-			);
-		}
-
-		return $response;
 	}
 
 	/**
@@ -181,18 +191,11 @@ class WP_HTTPS_Detection {
 	 * But it only looks at the HTML document in the $response body.
 	 * If a script requests an insecure script, this will not detect that.
 	 *
-	 * @param array $response The response from a wp_remote_request().
-	 * @return array|WP_Error The URLs for insecure content, or a WP_Error.
+	 * @param string $body The response body from a wp_remote_request().
+	 * @return array The URLs for insecure content.
 	 */
-	public function get_insecure_content( $response ) {
+	public function get_insecure_content( $body ) {
 		$libxml_previous_state = libxml_use_internal_errors( true );
-		$body                  = wp_remote_retrieve_body( $response );
-		if ( empty( $body ) ) {
-			return new WP_Error(
-				'insecure_content_request_empty_body',
-				__( 'The request for insecure content returned an empty body.', 'pwa' )
-			);
-		}
 
 		$dom = new DOMDocument( '1.0' );
 		$dom->loadHTML( $body );

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -101,21 +101,10 @@ class WP_HTTPS_UI {
 			self::OPTION_GROUP,
 			self::UPGRADE_HTTPS_OPTION,
 			array(
-				'type'              => 'string',
-				'sanitize_callback' => array( $this, 'upgrade_https_sanitize_callback' ),
+				'type'              => 'boolean',
+				'sanitize_callback' => 'rest_sanitize_boolean',
 			)
 		);
-	}
-
-	/**
-	 * Sanitization callback for the upgrade HTTPS option.
-	 *
-	 * @param string $raw_value The value to sanitize.
-	 * @return bool Whether the option is true or false.
-	 */
-	public function upgrade_https_sanitize_callback( $raw_value ) {
-		unset( $raw_value );
-		return isset( $_POST[ self::UPGRADE_HTTPS_OPTION ] ); // WPCS: CSRF OK.
 	}
 
 	/**

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -126,14 +126,12 @@ class WP_HTTPS_UI {
 	 * This UI would not apply if those URLs are already HTTPS.
 	 */
 	public function add_settings_field() {
-		if ( ! $this->wp_https_detection->is_currently_https() ) {
-			add_settings_field(
-				self::HTTPS_SETTING_ID,
-				__( 'HTTPS', 'pwa' ),
-				array( $this, 'render_https_settings' ),
-				self::OPTION_GROUP
-			);
-		}
+		add_settings_field(
+			self::HTTPS_SETTING_ID,
+			__( 'HTTPS', 'pwa' ),
+			array( $this, 'render_https_settings' ),
+			self::OPTION_GROUP
+		);
 	}
 
 	/**
@@ -291,6 +289,8 @@ class WP_HTTPS_UI {
 
 	/**
 	 * Conditionally filters the 'siteurl' and 'home' values from the wp-config and options.
+	 *
+	 * Note that these run at priority 11 so that they apply after _config_wp_home().
 	 */
 	public function filter_site_url_and_home() {
 		if ( get_option( self::UPGRADE_HTTPS_OPTION ) && ! $this->wp_https_detection->is_currently_https() ) {
@@ -337,6 +337,8 @@ class WP_HTTPS_UI {
 
 	/**
 	 * Conditionally redirects HTTP requests to HTTPS.
+	 *
+	 * @todo This does not appear to be necessary because redirect_canonical() will do everything.
 	 *
 	 * Does not apply if is_admin().
 	 * So if the SSL certificate expires somehow, the admin won't be locked out of wp-admin.

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -127,6 +127,11 @@ class WP_HTTPS_UI {
 	 * Renders the HTTPS settings in /wp-admin on the General Settings page.
 	 */
 	public function render_https_settings() {
+		$https_support = get_option( WP_HTTPS_Detection::HTTPS_SUPPORT_OPTION_NAME );
+		if ( empty( $https_support ) ) {
+			return;
+		}
+
 		$upgrade_https_value = (bool) get_option( self::UPGRADE_HTTPS_OPTION );
 		$https_more_details  = sprintf(
 			'<a href="%s">%s</a>',
@@ -144,6 +149,17 @@ class WP_HTTPS_UI {
 			) );
 			?>
 		</p>
+
+		<?php if ( is_wp_error( $https_support ) ) : ?>
+			<?php foreach ( $https_support->get_error_messages() as $error_message ) : ?>
+				<div class="notice notice-error inline">
+					<p>
+						<?php echo esc_html( $error_message ); ?>
+					</p>
+				</div>
+			<?php endforeach; ?>
+		<?php endif; ?>
+
 		<p>
 			<label><input name="<?php echo esc_attr( self::UPGRADE_HTTPS_OPTION ); ?>" type="checkbox" <?php checked( $upgrade_https_value ); ?> value="<?php echo esc_attr( self::OPTION_CHECKED_VALUE ); ?>"><?php esc_html_e( 'Upgrade to secure connection', 'pwa' ); ?></label>
 		</p>
@@ -176,7 +192,7 @@ class WP_HTTPS_UI {
 			)
 		);
 
-		/**
+		/*
 		 * Add class="hidden" to this <div> if the 'HTTPS Upgrade' checkbox isn't checked.
 		 * This insecure content UI does not apply if the user isn't upgrading to HTTPS,
 		 * as there will be no need to upgrade insecure requests.

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -82,7 +82,7 @@ class WP_HTTPS_UI {
 		add_action( 'admin_init', array( $this, 'init_admin' ) );
 		add_action( 'init', array( $this, 'filter_site_url_and_home' ) );
 		add_action( 'init', array( $this, 'filter_header' ) );
-		add_action( 'wp_loaded', array( $this, 'conditionally_redirect_to_https' ) );
+		add_action( 'template_redirect', array( $this, 'conditionally_redirect_to_https' ) );
 	}
 
 	/**
@@ -329,14 +329,11 @@ class WP_HTTPS_UI {
 	 *
 	 * @todo This does not appear to be necessary because redirect_canonical() will do everything.
 	 *
-	 * Does not apply if is_admin().
 	 * So if the SSL certificate expires somehow, the admin won't be locked out of wp-admin.
 	 */
 	public function conditionally_redirect_to_https() {
 		$do_redirect = (
 			! is_ssl()
-			&&
-			! is_admin()
 			&&
 			get_option( self::UPGRADE_HTTPS_OPTION ) // The checkbox to upgrade to HTTPS is checked.
 			&&

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -96,7 +96,7 @@ class WP_Web_App_Manifest {
 	 */
 	public function get_manifest() {
 		$manifest = array(
-			'name'      => get_bloginfo( 'name' ),
+			'name'      => wp_kses_decode_entities( get_bloginfo( 'name' ) ),
 			'start_url' => get_home_url(),
 			'display'   => 'minimal-ui',
 			'dir'       => is_rtl() ? 'rtl' : 'ltr',
@@ -114,7 +114,7 @@ class WP_Web_App_Manifest {
 		 *
 		 * @link https://stackoverflow.com/questions/12646197/cut-the-string-to-be-80-characters-and-must-keep-the-words-without-cutting-th#answer-12646400
 		 */
-		preg_match( '/^.{0,12}(?= |$)/', get_bloginfo( 'name' ), $short_name_matches );
+		preg_match( '/^.{0,12}(?= |$)/', $manifest['name'], $short_name_matches );
 		if ( $short_name_matches ) {
 			$manifest['short_name'] = $short_name_matches[0];
 		}
@@ -125,7 +125,7 @@ class WP_Web_App_Manifest {
 			$manifest['theme_color']      = $theme_color;
 		}
 
-		$description = get_bloginfo( 'description' );
+		$description = wp_kses_decode_entities( get_bloginfo( 'description' ) );
 		if ( $description ) {
 			$manifest['description'] = $description;
 		}


### PR DESCRIPTION
* Always do HTTPS loopback tests even when HTTPS is supposedly enabled.
* Always show checkbox, even when HTTPS is currently enabled. (As it could be enabled temporarily.)
* When doing HTTPS loopback requests, store any errors and show them next to the checkbox.
* Allow HTTPS checkbox to be submitted even when there are errors. This is critical for self-signed certificates as in a development environment.
* Do HTTPS redirection at `template_redirect` instead of `wp_loaded`.

![image](https://user-images.githubusercontent.com/134745/45341432-7e407f00-b54f-11e8-9680-55e4cdea8d4a.png)

Also:

* Prevent HTML entities from being served in name, short_name, and description fields in web app manifest.