### PR TITLE
Update Web App Manifest endpoint to /wp/v2/web-app-manifest

### DIFF
--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -36,7 +36,7 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	const EXPECTED_ROUTE = '/app/v1/web-manifest';
+	const EXPECTED_ROUTE = '/pwa/v1/web-manifest';
 
 	/**
 	 * Image mime_type.

--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -36,7 +36,7 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	const EXPECTED_ROUTE = '/pwa/v1/web-manifest';
+	const EXPECTED_ROUTE = '/wp/v2/web-app-manifest';
 
 	/**
 	 * Image mime_type.

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -24,7 +24,7 @@ class WP_Web_App_Manifest {
 	 *
 	 * @var string
 	 */
-	const REST_NAMESPACE = 'app/v1';
+	const REST_NAMESPACE = 'pwa/v1';
 
 	/**
 	 * The REST API route for the manifest request.

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -24,7 +24,7 @@ class WP_Web_App_Manifest {
 	 *
 	 * @var string
 	 */
-	const REST_NAMESPACE = 'pwa/v1';
+	const REST_NAMESPACE = 'wp/v2';
 
 	/**
 	 * The REST API route for the manifest request.

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -31,7 +31,7 @@ class WP_Web_App_Manifest {
 	 *
 	 * @var string
 	 */
-	const REST_ROUTE = '/web-manifest';
+	const REST_ROUTE = '/web-app-manifest';
 
 	/**
 	 * The default manifest icon sizes.


### PR DESCRIPTION
Just looked at a couple of projects I am following, they actually register new endpoints to WP Api using `app` as part of the namespace.

Wouldn't be `app` more suitable as general namespace for theme-registered endpoints?

Wouldn't be `pwa` (official plugin slug) more appropriate the plugin's rest namespace? 

Adriano