### PR TITLE
 Prevent doing secondary fetch when navigation preload is enabled

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,6 @@
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 6
+		"ecmaVersion": 8
 	}
 }

--- a/wp-includes/js/service-worker-error-response-handling.js
+++ b/wp-includes/js/service-worker-error-response-handling.js
@@ -1,43 +1,60 @@
 /* global console, ERROR_OFFLINE_URL, ERROR_500_URL, BLACKLIST_PATTERNS */
 
-// @todo Should this use setDefaultHandler?
 wp.serviceWorker.routing.registerRoute( new wp.serviceWorker.routing.NavigationRoute(
-	( {event} ) => {
-		return fetch( event.request )
-			.then( ( response ) => {
-				if ( response.status < 500 ) {
-					return response;
+	async function ( { event } ) {
+		const { url } = event.request;
+
+		const handleResponse = ( response ) => {
+			if ( response.status < 500 ) {
+				return response;
+			}
+			const channel = new BroadcastChannel( 'wordpress-server-errors' );
+
+			// Wait for client to request the error message.
+			channel.onmessage = ( event ) => {
+				if ( event.data && event.data.clientUrl && url === event.data.clientUrl ) {
+					response.text().then( ( text ) => {
+						channel.postMessage({
+							requestUrl: url,
+							bodyText: text,
+							status: response.status,
+							statusText: response.statusText
+						});
+						channel.close();
+					} );
 				}
-				const { request } = event;
-				const channel = new BroadcastChannel( 'wordpress-server-errors' );
+			};
 
-				// Wait for client to request the error message.
-				channel.onmessage = ( event ) => {
-					if ( event.data && event.data.clientUrl && request.url === event.data.clientUrl ) {
-						response.text().then( ( text ) => {
-							channel.postMessage({
-								requestUrl: request.url,
-								bodyText: text,
-								status: response.status,
-								statusText: response.statusText
-							});
-							channel.close();
-						} );
-					}
-				};
+			// Close the channel if client did not request the message within 30 seconds.
+			setTimeout( () => {
+				channel.close();
+			}, 30 * 1000 );
 
-				// Close the channel if client did not request the message within 30 seconds.
-				setTimeout( () => {
-					channel.close();
-				}, 30 * 1000 );
+			return caches.match( ERROR_500_URL );
+		};
 
-				return caches.match( ERROR_500_URL );
-			} )
-			.catch( ( error ) => {
-				console.error( error ); // eslint-disable-line no-console
+		const sendOfflineResponse = () => {
+			return caches.match( ERROR_OFFLINE_URL );
+		};
 
-				return caches.match( ERROR_OFFLINE_URL ) || error;
-			} );
+		/*
+		 * If navigation preload is enabled, use the preload request instead of doing another fetch.
+		 * This prevents requests from being duplicated. See <https://github.com/xwp/pwa-wp/issues/67>.
+		 */
+		if ( event.preloadResponse ) {
+			try {
+				const response = await event.preloadResponse;
+				if ( response ) {
+					return handleResponse( response );
+				}
+			} catch ( error ) {
+				return sendOfflineResponse();
+			}
+		}
+
+		return fetch( event.request )
+			.then( handleResponse )
+			.catch( sendOfflineResponse );
 	},
 	{
 		blacklist: BLACKLIST_PATTERNS.map( ( pattern ) => new RegExp( pattern ) )


### PR DESCRIPTION
Fixes #67. See https://github.com/xwp/pwa-wp/issues/67#issuecomment-423247642.

