### PR TITLE
[WIP] Conditionally add HSTS header

### DIFF
--- a/tests/test-class-wp-https-detection.php
+++ b/tests/test-class-wp-https-detection.php
@@ -206,9 +206,38 @@ class Test_WP_HTTPS_Detection extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test update_successful_https_check.
+	 *
+	 * @covers WP_HTTPS_Detection::update_successful_https_check()
+	 */
+	public function test_update_successful_https_check() {
+		$last_check = time();
+		update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, $last_check );
+		$support_errors = new WP_Error();
+
+		// None of the conditions in the method is met, so this should not update the option.
+		$this->instance->update_successful_https_check( $support_errors );
+		$this->assertEquals( $last_check, get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK ) );
+
+		// There is no support error or current option value, this should update it.
+		update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, null );
+		$this->instance->update_successful_https_check( $support_errors );
+		$this->assertNotEmpty( get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK ) );
+
+		// There is a support error, so this should set the option to null.
+		$support_errors->add(
+			'ssl_verification_failed',
+			'The SSL verification failed'
+		);
+		update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, null );
+		$this->instance->update_successful_https_check( $support_errors );
+		$this->assertNull( get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK ) );
+	}
+
+	/**
 	 * Test is_currently_https.
 	 *
-	 * @covers WP_HTTPS_UI::is_currently_https()
+	 * @covers WP_HTTPS_Detection::is_currently_https()
 	 */
 	public function test_is_currently_https() {
 		// If both of these options have an HTTP URL, the method should return false.

--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -337,7 +337,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$this->assertEquals( WP_HTTPS_UI::DAY_IN_SECONDS, $this->instance->get_hsts_header_expiration() );
 
 		// If it's been 2 months, 2 weeks, and an hour since the first consecutive successful check, this should have a 1-month expiration.
-		update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, $time - ( WP_HTTPS_UI::MONTH_IN_SECONDS + WP_HTTPS_UI::WEEK_IN_SECONDS * 2  + $hour_in_seconds ) );
+		update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, $time - ( WP_HTTPS_UI::MONTH_IN_SECONDS + WP_HTTPS_UI::WEEK_IN_SECONDS * 2 + $hour_in_seconds ) );
 		$this->assertEquals( WP_HTTPS_UI::MONTH_IN_SECONDS, $this->instance->get_hsts_header_expiration() );
 	}
 

--- a/tests/test-class-wp-https-ui.php
+++ b/tests/test-class-wp-https-ui.php
@@ -84,7 +84,7 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 		$this->instance->init();
 		$this->assertEquals( 10, has_action( 'admin_init', array( $this->instance, 'init_admin' ) ) );
 		$this->assertEquals( 10, has_action( 'init', array( $this->instance, 'filter_site_url_and_home' ) ) );
-		$this->assertEquals( 10, has_action( 'init', array( $this->instance, 'filter_header' ) ) );
+		$this->assertEquals( 10, has_action( 'init', array( $this->instance, 'conditionally_upgrade_insecure_requests' ) ) );
 		$this->assertEquals( 10, has_action( 'init', array( $this->instance, 'conditionally_add_hsts_header' ) ) );
 		$this->assertEquals( 11, has_action( 'template_redirect', array( $this->instance, 'conditionally_redirect_to_https' ) ) );
 	}
@@ -240,19 +240,19 @@ class Test_WP_HTTPS_UI extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test filter_header.
+	 * Test conditionally_upgrade_insecure_requests.
 	 *
-	 * @covers WP_HTTPS_UI::filter_header()
+	 * @covers WP_HTTPS_UI::conditionally_upgrade_insecure_requests()
 	 */
-	public function test_filter_header() {
+	public function test_conditionally_upgrade_insecure_requests() {
 		// If the option to upgrade to HTTPS is not true, this should not add the filter.
 		update_option( WP_HTTPS_UI::UPGRADE_HTTPS_OPTION, '' );
-		$this->instance->filter_header();
+		$this->instance->conditionally_upgrade_insecure_requests();
 		$this->assertFalse( has_filter( 'wp_headers', array( $this->instance, 'upgrade_insecure_requests' ) ) );
 
 		// If the option to upgrade to HTTPS is true, this should add the filter.
 		update_option( WP_HTTPS_UI::UPGRADE_HTTPS_OPTION, true );
-		$this->instance->filter_header();
+		$this->instance->conditionally_upgrade_insecure_requests();
 		$this->assertEquals( 10, has_filter( 'wp_headers', array( $this->instance, 'upgrade_insecure_requests' ) ) );
 		remove_filter( 'wp_headers', array( $this->instance, 'upgrade_insecure_requests' ) );
 

--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -134,7 +134,22 @@ class WP_HTTPS_Detection {
 			self::HTTPS_SUPPORT_OPTION_NAME,
 			empty( $support_errors->errors ) ? true : $support_errors
 		);
+		$this->update_successful_https_check( $support_errors );
 
+		if ( $body ) {
+			update_option( self::INSECURE_CONTENT_OPTION_NAME, $this->get_insecure_content( $body ) );
+		}
+	}
+
+	/**
+	 * Updates the time of the first consecutive successful HTTPS check.
+	 *
+	 * Returns true only if the siteurl and home option values are HTTPS.
+	 * These are also known as the WordPress Address (URL) and Site Address (URL) in the 'General Settings' page.
+	 *
+	 * @param WP_Error $support_errors The HTTPS support errors.
+	 */
+	public function update_successful_https_check( $support_errors ) {
 		$last_successful_check = get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK );
 		if ( empty( $support_errors->errors ) ) {
 			if ( ! $last_successful_check ) {
@@ -144,10 +159,6 @@ class WP_HTTPS_Detection {
 		} elseif ( $last_successful_check ) {
 			// There was a support error, so set the last successful check to null, as this check failed.
 			update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, null );
-		}
-
-		if ( $body ) {
-			update_option( self::INSECURE_CONTENT_OPTION_NAME, $this->get_insecure_content( $body ) );
 		}
 	}
 

--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -135,6 +135,17 @@ class WP_HTTPS_Detection {
 			empty( $support_errors->errors ) ? true : $support_errors
 		);
 
+		$last_successful_check = get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK );
+		if ( empty( $support_errors->errors ) ) {
+			if ( ! $last_successful_check ) {
+				// There was no support error and no last consecutive successful HTTPS check, so save this has a successful check.
+				update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, time() );
+			}
+		} elseif ( $last_successful_check ) {
+			// There was a support error, so set the last successful check to null, as this check failed.
+			update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, null );
+		}
+
 		if ( $body ) {
 			update_option( self::INSECURE_CONTENT_OPTION_NAME, $this->get_insecure_content( $body ) );
 		}

--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -144,20 +144,18 @@ class WP_HTTPS_Detection {
 
 	/**
 	 * Updates the time of the first consecutive successful HTTPS check.
-	 *
-	 * Returns true only if the siteurl and home option values are HTTPS.
-	 * These are also known as the WordPress Address (URL) and Site Address (URL) in the 'General Settings' page.
+	 * This time is used to determine whether HSTS headers should be added.
 	 *
 	 * @param WP_Error $support_errors The HTTPS support errors.
 	 */
 	public function update_successful_https_check( $support_errors ) {
-		$last_successful_check = get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK );
+		$first_successful_check = get_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK );
 		if ( empty( $support_errors->errors ) ) {
-			if ( ! $last_successful_check ) {
+			if ( ! $first_successful_check ) {
 				// There was no support error and no last consecutive successful HTTPS check, so save this has a successful check.
 				update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, time() );
 			}
-		} elseif ( $last_successful_check ) {
+		} elseif ( $first_successful_check ) {
 			// There was a support error, so set the last successful check to null, as this check failed.
 			update_option( WP_HTTPS_UI::TIME_SUCCESSFUL_HTTPS_CHECK, null );
 		}

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -29,10 +29,7 @@ class WP_HTTPS_UI {
 	 *
 	 * This is used to determine if HSTS is used.
 	 * As long as HTTPS loopback requests succeed, this time will remain the same.
-	 * But a single failed check will set this to null.
-	 * If the last successful HTTPS loopback was less than 2 weeks ago,
-	 * this will not add an HSTS header.
-	 * Also, this is reset on unchecking the checkbox to upgrade to HTTPS, stored in the option self::UPGRADE_HTTPS_OPTION.
+	 * But a single failed check will set this to ''.
 	 *
 	 * @var string
 	 */
@@ -387,11 +384,10 @@ class WP_HTTPS_UI {
 	 */
 	public function conditionally_add_hsts_header( $headers ) {
 		$expiration = $this->get_hsts_header_expiration();
-		if ( ! $expiration || ! get_option( self::UPGRADE_HTTPS_OPTION ) ) {
-			return $headers;
+		if ( $expiration && get_option( self::UPGRADE_HTTPS_OPTION ) ) {
+			$headers['Strict-Transport-Security'] = 'max-age=' . intval( $expiration );
 		}
 
-		$headers['Strict-Transport-Security'] = 'max-age=' . intval( $expiration );
 		return $headers;
 	}
 

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -116,7 +116,7 @@ class WP_HTTPS_UI {
 	public function init() {
 		add_action( 'admin_init', array( $this, 'init_admin' ) );
 		add_action( 'init', array( $this, 'filter_site_url_and_home' ) );
-		add_action( 'init', array( $this, 'filter_header' ) );
+		add_action( 'init', array( $this, 'conditionally_upgrade_insecure_requests' ) );
 		add_action( 'init', array( $this, 'conditionally_add_hsts_header' ) );
 		add_action( 'template_redirect', array( $this, 'conditionally_redirect_to_https' ), 11 ); // At 11 to run after redirect_canonical().
 	}
@@ -358,7 +358,7 @@ class WP_HTTPS_UI {
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade-Insecure-Requests
 	 */
-	public function filter_header() {
+	public function conditionally_upgrade_insecure_requests() {
 		if ( get_option( self::UPGRADE_HTTPS_OPTION ) ) {
 			add_filter( 'wp_headers', array( $this, 'upgrade_insecure_requests' ) );
 		}


### PR DESCRIPTION
* Begins the work of adding an HSTS header
* Follows @westonruter's [suggested](https://github.com/xwp/pwa-wp/issues/56#issuecomment-417024175) 'burn-in' period for HSTS 

@todos include:
* Maybe expiring HSTS if a certificate expires, probably by setting the `max-age` to 0:
>Should it be necessary to disable Strict Transport Security, setting the max-age to 0 (over a https connection) will immediately expire the Strict-Transport-Security header, allowing access via http. ([source](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#How_the_browser_handles_it))

Closes #18.