### PR TITLE
Inline workbox-sw.js in non-WP_DEBUG to eliminate HTTP request

### DIFF
--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -54,10 +54,17 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 		$current_scope = wp_service_workers()->get_current_scope();
 		$workbox_dir   = 'wp-includes/js/workbox-v3.6.1/';
 
-		$script = sprintf(
-			"importScripts( %s );\n",
-			wp_service_worker_json_encode( PWA_PLUGIN_URL . $workbox_dir . 'workbox-sw.js' )
-		);
+		if ( WP_DEBUG ) {
+			// Load with importScripts() so that source map is available.
+			$script = sprintf(
+				"importScripts( %s );\n",
+				wp_service_worker_json_encode( PWA_PLUGIN_URL . $workbox_dir . 'workbox-sw.js' )
+			);
+		} else {
+			// Inline the workbox-sw.js to avoid an additional HTTP request.
+			$script = file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$script = preg_replace( '://# sourceMappingURL=.+?\.map:', '', $script );
+		}
 
 		$options = array(
 			'debug'            => WP_DEBUG,


### PR DESCRIPTION
Fixes #93.

> We can avoid an additional HTTP request for each installation of the service worker by inlining the `workbox-sw.js` file into the service worker response instead of requesting it via `importScript()`

But when `WP_DEBUG` is enabled, then we can continue loading via `importScripts` so that we can take advantage of the source map.