### PR TITLE
Fix navigation routing blacklist in admin causing warning regarding preloadResponse

### DIFF
--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -438,14 +438,16 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 	public function get_blacklist_patterns() {
 		$blacklist_patterns = array();
 
-		// Exclude admin URLs.
-		$blacklist_patterns[] = '^' . preg_quote( untrailingslashit( wp_parse_url( admin_url(), PHP_URL_PATH ) ), '/' ) . '($|\?.*|/.*)';
+		if ( ! is_admin() ) {
+			// Exclude admin URLs, if not in the admin.
+			$blacklist_patterns[] = '^' . preg_quote( untrailingslashit( wp_parse_url( admin_url(), PHP_URL_PATH ) ), '/' ) . '($|\?.*|/.*)';
+
+			// Exclude PHP files (e.g. wp-login.php).
+			$blacklist_patterns[] = '[^\?]*.\.php($|\?.*)';
+		}
 
 		// Exclude REST API.
 		$blacklist_patterns[] = '^' . preg_quote( wp_parse_url( get_rest_url(), PHP_URL_PATH ), '/' ) . '.*';
-
-		// Exclude PHP files (e.g. wp-login.php).
-		$blacklist_patterns[] = '[^\?]*.\.php($|\?.*)';
 
 		// Exclude service worker and stream fragment requests (to ease debugging).
 		$blacklist_patterns[] = '.*\?(.*&)?(' . join( '|', array( self::STREAM_FRAGMENT_QUERY_VAR, WP_Service_Workers::QUERY_VAR ) ) . ')=';

--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -119,3 +119,8 @@ wp.serviceWorker.routing.registerRoute( new wp.serviceWorker.routing.NavigationR
 		blacklist: BLACKLIST_PATTERNS.map( ( pattern ) => new RegExp( pattern ) )
 	}
 ) );
+
+// Add fallback network-only navigation route to ensure preloadResponse is used if available.
+wp.serviceWorker.routing.registerRoute( new wp.serviceWorker.routing.NavigationRoute(
+	wp.serviceWorker.strategies.networkOnly()
+) );


### PR DESCRIPTION
Fixes #96.

The admin URLs were getting blacklisted from the `NavigationRoute` and so the `preloadResponse` was being cancelled/discarded. This also fixes the issue where the offline template was not being served when navigating to the admin while offline.

Many thanks to @jeffposnick for helping troubleshoot this.