### PR TITLE
Add theme-color theme support

### DIFF
--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -61,7 +61,7 @@ class WP_Web_App_Manifest {
 	public function manifest_link_and_meta() {
 		?>
 		<link rel="manifest" href="<?php echo esc_url( rest_url( self::REST_NAMESPACE . self::REST_ROUTE ) ); ?>">
-		<meta name="theme-color" content="<?php echo esc_attr( apply_filters( 'theme_color_meta', $this->get_theme_color() ) ); ?>">
+		<meta name="theme-color" content="<?php echo esc_attr( $this->get_theme_color() ); ?>">
 		<?php
 	}
 
@@ -85,7 +85,7 @@ class WP_Web_App_Manifest {
 			$theme_color = self::FALLBACK_THEME_COLOR;
 		}
 
-		return $theme_color;
+		return apply_filters( 'theme_color_meta', $theme_color );
 	}
 
 	/**

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -74,18 +74,25 @@ class WP_Web_App_Manifest {
 	 * @return string $theme_color The theme color for the manifest.json file, as a hex value.
 	 */
 	public function get_theme_color() {
-		if ( current_theme_supports( 'custom-background' ) ) {
-			$background_color = get_background_color(); // This returns a hex value without the leading #, or an empty string.
-			if ( $background_color ) {
-				$theme_color = "#{$background_color}";
+
+		// Check if the current theme supports theme-color and a color is defined.
+		if ( current_theme_supports( 'theme-color' ) ) {
+			$theme_color = get_theme_support( 'theme-color' );
+			if ( $theme_color ) {
+				return $theme_color;
 			}
 		}
 
-		if ( ! isset( $theme_color ) ) {
-			$theme_color = self::FALLBACK_THEME_COLOR;
+		// Check if the current theme supports custom-background and a color is defined.
+		if ( current_theme_supports( 'custom-background' ) ) {
+			$background_color = get_background_color(); // This returns a hex value without the leading #, or an empty string.
+			if ( $background_color ) {
+				return "#{$background_color}";
+			}
 		}
 
-		return apply_filters( 'theme_color_meta', $theme_color );
+		// Fallback color.
+		return self::FALLBACK_THEME_COLOR;
 	}
 
 	/**

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -61,7 +61,7 @@ class WP_Web_App_Manifest {
 	public function manifest_link_and_meta() {
 		?>
 		<link rel="manifest" href="<?php echo esc_url( rest_url( self::REST_NAMESPACE . self::REST_ROUTE ) ); ?>">
-		<meta name="theme-color" content="<?php echo esc_attr( $this->get_theme_color() ); ?>">
+		<meta name="theme-color" content="<?php echo esc_attr( apply_filters( 'theme_color_meta', $this->get_theme_color() ) ); ?>">
 		<?php
 	}
 


### PR DESCRIPTION
When a theme has `custom-background` theme support, this is used as the theme color for the app. When the theme doesn't have a `custom-background` or the background color is not what is desired for the app, then a way to override it is needed without resorting to the fallback theme color. To this end, the `theme-color` theme support is introduced in this PR.

Closes #116.