### PR TITLE
Fix logic for determining whether on front domain or admin domain

### DIFF
--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -119,8 +119,8 @@ function wp_print_service_workers() {
 	$home_host  = wp_parse_url( home_url(), PHP_URL_HOST );
 	$admin_host = wp_parse_url( admin_url(), PHP_URL_HOST );
 
-	$home_url   = ( $home_port ) ? "$home_host:$home_port" : $home_host;
-	$admin_url  = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_port;
+	$home_url  = ( $home_port ) ? "$home_host:$home_port" : $home_host;
+	$admin_url = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_port;
 
 	$on_front_domain = isset( $_SERVER['HTTP_HOST'] ) && $home_url === $_SERVER['HTTP_HOST'];
 	$on_admin_domain = isset( $_SERVER['HTTP_HOST'] ) && $admin_url === $_SERVER['HTTP_HOST'];

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -113,14 +113,14 @@ function wp_print_service_workers() {
 	global $pagenow;
 	$scopes = array();
 
-	$home_port = wp_parse_url( home_url(), PHP_URL_PORT );
+	$home_port  = wp_parse_url( home_url(), PHP_URL_PORT );
 	$admin_port = wp_parse_url( admin_url(), PHP_URL_PORT );
 
-	$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+	$home_host  = wp_parse_url( home_url(), PHP_URL_HOST );
 	$admin_host = wp_parse_url( admin_url(), PHP_URL_HOST );
 
-	$home_url = ( $home_port ) ? "$home_host:$home_port" : $home_host;
-	$admin_url = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_port;
+	$home_url   = ( $home_port ) ? "$home_host:$home_port" : $home_host;
+	$admin_url  = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_port;
 
 	$on_front_domain = isset( $_SERVER['HTTP_HOST'] ) && $home_url === $_SERVER['HTTP_HOST'];
 	$on_admin_domain = isset( $_SERVER['HTTP_HOST'] ) && $admin_url === $_SERVER['HTTP_HOST'];

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -113,8 +113,17 @@ function wp_print_service_workers() {
 	global $pagenow;
 	$scopes = array();
 
-	$on_front_domain = isset( $_SERVER['HTTP_HOST'] ) && wp_parse_url( home_url(), PHP_URL_HOST ) === $_SERVER['HTTP_HOST'];
-	$on_admin_domain = isset( $_SERVER['HTTP_HOST'] ) && wp_parse_url( admin_url(), PHP_URL_HOST ) === $_SERVER['HTTP_HOST'];
+	$home_port = wp_parse_url( home_url(), PHP_URL_PORT );
+	$admin_port = wp_parse_url( admin_url(), PHP_URL_PORT );
+
+	$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+	$admin_host = wp_parse_url( admin_url(), PHP_URL_HOST );
+
+	$home_url = ( $home_port ) ? "$home_host:$home_port" : $home_host;
+	$admin_url = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_port;
+
+	$on_front_domain = isset( $_SERVER['HTTP_HOST'] ) && $home_url === $_SERVER['HTTP_HOST'];
+	$on_admin_domain = isset( $_SERVER['HTTP_HOST'] ) && $admin_url === $_SERVER['HTTP_HOST'];
 
 	// Install the front service worker if currently on the home domain.
 	if ( $on_front_domain ) {

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -120,7 +120,7 @@ function wp_print_service_workers() {
 	$admin_host = wp_parse_url( admin_url(), PHP_URL_HOST );
 
 	$home_url  = ( $home_port ) ? "$home_host:$home_port" : $home_host;
-	$admin_url = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_port;
+	$admin_url = ( $admin_port ) ? "$admin_host:$admin_port" : $admin_host;
 
 	$on_front_domain = isset( $_SERVER['HTTP_HOST'] ) && $home_url === $_SERVER['HTTP_HOST'];
 	$on_admin_domain = isset( $_SERVER['HTTP_HOST'] ) && $admin_url === $_SERVER['HTTP_HOST'];


### PR DESCRIPTION
Resolves #119 by taking port into account when determining whether the request is on admin or front. Previous to this, if a port was included in `home_url()` or `admin_url()`, the respective `$on_front_domain` and `$on_admin_domain` variables would always evaluate to false.

This PR is based on #121.