### PR TITLE
Add missing precaching.getCacheKeyForURL() calls URLs passed to caches.match()

### DIFF
--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -41,7 +41,7 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 			}
 
 			if ( canStreamResponse() ) {
-				return caches.match( ERROR_500_BODY_FRAGMENT_URL );
+				return caches.match( wp.serviceWorker.precaching.getCacheKeyForURL( ERROR_500_BODY_FRAGMENT_URL ) );
 			}
 
 			const originalResponse = response.clone();
@@ -52,7 +52,7 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 					return originalResponse;
 				}
 
-				return caches.match( ERROR_500_URL ).then( function( errorResponse ) {
+				return caches.match( wp.serviceWorker.precaching.getCacheKeyForURL( ERROR_500_URL ) ).then( function( errorResponse ) {
 
 					if ( ! errorResponse ) {
 						return response;
@@ -100,11 +100,10 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 
 		const sendOfflineResponse = () => {
 			if ( canStreamResponse() ) {
-				return caches.match( ERROR_OFFLINE_BODY_FRAGMENT_URL );
+				return caches.match( wp.serviceWorker.precaching.getCacheKeyForURL( ERROR_OFFLINE_BODY_FRAGMENT_URL ) );
 			}
 
-			return caches.match( ERROR_OFFLINE_URL ).then( function( response ) {
-
+			return caches.match( wp.serviceWorker.precaching.getCacheKeyForURL( ERROR_OFFLINE_URL ) ).then( function( response ) {
 				return response.text().then( function( text ) {
 					let init = {
 						status: response.status,

--- a/wp-includes/js/service-worker-offline-commenting.js
+++ b/wp-includes/js/service-worker-offline-commenting.js
@@ -16,7 +16,7 @@
 
 				// @todo This is duplicated with code in service-worker-navigation-routing.js.
 				return response.text().then( function( errorText ) {
-					return caches.match( ERROR_500_URL ).then( function( errorResponse ) {
+					return caches.match( wp.serviceWorker.precaching.getCacheKeyForURL( ERROR_500_URL ) ).then( function( errorResponse ) {
 
 						if ( ! errorResponse ) {
 							return response;
@@ -84,7 +84,7 @@
 				);
 
 				// @todo This is duplicated with code in service-worker-navigation-routing.js.
-				return caches.match( ERROR_OFFLINE_URL ).then( function( response ) {
+				return caches.match( wp.serviceWorker.precaching.getCacheKeyForURL( ERROR_OFFLINE_URL ) ).then( function( response ) {
 
 					return response.text().then( function( text ) {
 						let init = {


### PR DESCRIPTION
I noticed that the offline page was failing to be served by the service worker, and this in turn caused the PWA Lighthouse audit to complain with:

> Service worker does not successfully serve the manifest's start_url, No usable web app manifest found on page.

The fix is to add some logic that was missed in the update to Workbox 4 (#127). Namely, in [v4.0.0-beta.1](https://github.com/GoogleChrome/workbox/releases/tag/v4.0.0-beta.1):

> ![image](https://user-images.githubusercontent.com/134745/52314821-245eac80-2969-11e9-94bd-18fcbbf9dc03.png)

Actually also in v4.0.0-beta.1 the `getCacheKeyForUrl()` method was renamed to `getCacheKeyForURL()`.

Closes #115.