### PR TITLE
Prevent 404 handling for error template requests

### DIFF
--- a/wp-includes/class-wp.php
+++ b/wp-includes/class-wp.php
@@ -19,3 +19,22 @@ function pwa_add_error_template_query_var() {
 	$wp->add_query_var( WP_Service_Workers::QUERY_VAR );
 }
 add_action( 'init', 'pwa_add_error_template_query_var' );
+
+/**
+ * Prevent handling an offline template request as a 404 when there are no posts published.
+ *
+ * For a core merge, this logic should be incorporated into `WP::handle_404()`.
+ *
+ * @see \WP::handle_404()
+ *
+ * @param bool     $preempt  Whether to short-circuit default header status handling. Default false.
+ * @param WP_Query $wp_query WordPress Query object.
+ * @return bool
+ */
+function pwa_filter_pre_handle_404_for_error_template_requests( $preempt, WP_Query $wp_query ) {
+	if ( $wp_query->get( 'wp_error_template' ) ) {
+		$preempt = true;
+	}
+	return $preempt;
+}
+add_filter( 'pre_handle_404', 'pwa_filter_pre_handle_404_for_error_template_requests', 10, 2 );


### PR DESCRIPTION
When no posts are published on a site, the `WP::handle_404()` can end up sending a 404 status code for requests for the offline and 500 error templates. When this happens, the service worker fails to install. So this forcibly prevents 404-handling when requesting the offline templates.

I'm not in a place where I can test this at the moment, so it needs to be tested prior to merging. 

Fixes #144.