### PR TITLE
Replace WP_DEBUG with more appropriate flags

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -5,3 +5,4 @@ SKIP_ECHO_PATHS_SCOPE=1
 if [[ ! -z $TRAVIS ]]; then
 	CHECK_SCOPE=all
 fi
+CHECK_SCOPE=all

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -68,8 +68,8 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 			);
 		} else {
 			// Inline the workbox-sw.js to avoid an additional HTTP request.
-			$script .= file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			$script .= preg_replace( '://# sourceMappingURL=.+?\.map:', '', $script );
+			$wbjs    = file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$script .= preg_replace( '://# sourceMappingURL=.+?\.map\s*$:s', '', $wbjs );
 		}
 
 		$options = array(

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -54,16 +54,22 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 		$current_scope = wp_service_workers()->get_current_scope();
 		$workbox_dir   = 'wp-includes/js/workbox/';
 
+		$script = '';
 		if ( SCRIPT_DEBUG ) {
+			$enable_debug_log = defined( 'WP_SERVICE_WORKER_DEBUG_LOG' ) && WP_SERVICE_WORKER_DEBUG_LOG;
+			if ( ! $enable_debug_log ) {
+				$script .= "self.__WB_DISABLE_DEV_LOGS = true;\n";
+			}
+
 			// Load with importScripts() so that source map is available.
-			$script = sprintf(
+			$script .= sprintf(
 				"importScripts( %s );\n",
 				wp_service_worker_json_encode( PWA_PLUGIN_URL . $workbox_dir . 'workbox-sw.js' )
 			);
 		} else {
 			// Inline the workbox-sw.js to avoid an additional HTTP request.
-			$script = file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			$script = preg_replace( '://# sourceMappingURL=.+?\.map:', '', $script );
+			$script .= file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$script .= preg_replace( '://# sourceMappingURL=.+?\.map:', '', $script );
 		}
 
 		$options = array(

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -54,7 +54,7 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 		$current_scope = wp_service_workers()->get_current_scope();
 		$workbox_dir   = 'wp-includes/js/workbox/';
 
-		if ( WP_DEBUG ) {
+		if ( SCRIPT_DEBUG ) {
 			// Load with importScripts() so that source map is available.
 			$script = sprintf(
 				"importScripts( %s );\n",
@@ -67,7 +67,7 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 		}
 
 		$options = array(
-			'debug'            => WP_DEBUG,
+			'debug'            => SCRIPT_DEBUG, // When true, the dev builds are loaded. Otherwise, the prod builds are used.
 			'modulePathPrefix' => PWA_PLUGIN_URL . $workbox_dir,
 		);
 		$script .= sprintf( "workbox.setConfig( %s );\n", wp_service_worker_json_encode( $options ) );

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -189,7 +189,9 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 			$caching_strategy = WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY;
 
 			$revision = PWA_VERSION;
-			if ( WP_DEBUG ) {
+
+			// Force revision to be extra fresh during development (e.g. when PWA_VERSION is x.y-alpha).
+			if ( false !== strpos( PWA_VERSION, '-' ) ) {
 				$revision .= filemtime( PWA_PLUGIN_DIR . '/wp-admin/error.php' );
 				$revision .= filemtime( PWA_PLUGIN_DIR . '/wp-includes/service-workers.php' );
 			}


### PR DESCRIPTION
Fixes #170.

* Use `SCRIPT_DEBUG` to indicate that non-production sources of Workbox should be used.
* Look at `PWA_VERSION` instead of `WP_DEBUG` to determine if it is a dev version of the plugin.

By default the Workbox dev logs are disabled. To enable them, define this constant in the `wp-config.php`:

```php
define( 'WP_SERVICE_WORKER_DEBUG_LOG', true );
```

This only has any effect when `SCRIPT_DEBUG` is also enabled, as it causes the Workbox dev scripts to be used. When constant is present, the service worker will have the `__WB_DISABLE_DEV_LOGS` variable set which causes Workbox to not output the noisy logging messages. For more on that, https://github.com/GoogleChrome/workbox/issues/1619#issuecomment-557105799.