### PR TITLE
Eliminate need for disabling navigation preload while adding navigation request caching strategy

### DIFF
--- a/pwa.php
+++ b/pwa.php
@@ -100,6 +100,39 @@ if ( ! file_exists( __DIR__ . '/wp-includes/js/workbox/' ) || ! file_exists( __D
 	return;
 }
 
+/**
+ * Print admin notice when a build has not been been performed.
+ *
+ * This is temporary measure to correct a mistake in the example for how navigation request caching strategies.
+ *
+ * @since 0.3
+ */
+function _pwa_print_disabled_navigation_preload_notice() {
+	/** This filter is documented in wp-includes/components/class-wp-service-worker-navigation-routing-component.php */
+	$caching_strategy = apply_filters( 'wp_service_worker_navigation_caching_strategy', WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY );
+	if ( WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY === $caching_strategy ) {
+		return;
+	}
+	/** This filter is documented in wp-includes/components/class-wp-service-worker-navigation-routing-component.php */
+	if ( true === apply_filters( 'wp_service_worker_navigation_preload', true, WP_Service_Workers::SCOPE_FRONT ) ) {
+		return;
+	}
+	?>
+	<div class="notice notice-warning">
+		<p>
+			<?php
+			printf(
+				/* translators: %s: the wp_service_worker_navigation_preload filter call */
+				__( '<strong>PWA:</strong> Your theme or a plugin appears to have disabled navigation preload in order to enable a navigation caching stragegy. This was a workaround that is now no longer needed. Remove the following code from your theme/plugin to improve performance: <code>%s</code>.', 'pwa' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				'add_filter( \'wp_service_worker_navigation_preload\', \'__return_false\' )'
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', '_pwa_print_disabled_navigation_preload_notice' );
+
 /** WP_Web_App_Manifest Class */
 require_once PWA_PLUGIN_DIR . '/wp-includes/class-wp-web-app-manifest.php';
 

--- a/pwa.php
+++ b/pwa.php
@@ -109,7 +109,7 @@ if ( ! file_exists( __DIR__ . '/wp-includes/js/workbox/' ) || ! file_exists( __D
  * @return array Tests.
  */
 function _pwa_add_disabled_navigation_preload_site_status_test( $tests ) {
-	$tests['direct']['caching_plugin'] = array(
+	$tests['direct']['navigation_preload_enabled'] = array(
 		'label' => __( 'Navigation Preload Enabled', 'pwa' ),
 		'test'  => '_pwa_check_disabled_navigation_preload',
 	);

--- a/pwa.php
+++ b/pwa.php
@@ -101,37 +101,91 @@ if ( ! file_exists( __DIR__ . '/wp-includes/js/workbox/' ) || ! file_exists( __D
 }
 
 /**
+ * Register test for navigation preload being erroneously disabled.
+ *
+ * @since 0.3
+ *
+ * @param array $tests Tests.
+ * @return array Tests.
+ */
+function _pwa_add_disabled_navigation_preload_site_status_test( $tests ) {
+	$tests['direct']['caching_plugin'] = array(
+		'label' => __( 'Navigation Preload Enabled', 'pwa' ),
+		'test'  => '_pwa_check_disabled_navigation_preload',
+	);
+	return $tests;
+}
+add_filter( 'site_status_tests', '_pwa_add_disabled_navigation_preload_site_status_test' );
+
+/**
  * Print admin notice when a build has not been been performed.
  *
  * This is temporary measure to correct a mistake in the example for how navigation request caching strategies.
  *
+ * @todo Eventually add a test for enabling a navigation caching strategy.
  * @since 0.3
+ *
+ * @return array|null Test results.
  */
-function _pwa_print_disabled_navigation_preload_notice() {
+function _pwa_check_disabled_navigation_preload() {
+
 	/** This filter is documented in wp-includes/components/class-wp-service-worker-navigation-routing-component.php */
-	$caching_strategy = apply_filters( 'wp_service_worker_navigation_caching_strategy', WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY );
-	if ( WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY === $caching_strategy ) {
-		return;
+	$navigation_route_precache_entry = apply_filters(
+		'wp_service_worker_navigation_route',
+		array(
+			'url'      => null,
+			'revision' => '',
+		)
+	);
+
+	// Skip adding the navigation-preload test when using app shell since navigation preload is forcibly-disabled.
+	if ( ! empty( $navigation_route_precache_entry['url'] ) ) {
+		return null;
 	}
+
 	/** This filter is documented in wp-includes/components/class-wp-service-worker-navigation-routing-component.php */
-	if ( true === apply_filters( 'wp_service_worker_navigation_preload', true, WP_Service_Workers::SCOPE_FRONT ) ) {
-		return;
+	$navigation_preload_enabled = apply_filters( 'wp_service_worker_navigation_preload', true, WP_Service_Workers::SCOPE_FRONT );
+
+	if ( $navigation_preload_enabled ) {
+		$result = array(
+			'label'       => __( 'Navigation preload is enabled in service worker', 'pwa' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Performance', 'pwa' ),
+				'color' => 'blue',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				esc_html__( 'Navigation preload speeds up performance for return visitors when the service worker has been suspended.', 'pwa' )
+			),
+		);
+	} else {
+		$result = array(
+			'label'       => __( 'Navigation preload is being disabled in service worker', 'pwa' ),
+			'status'      => 'recommended',
+			'badge'       => array(
+				'label' => __( 'Performance', 'pwa' ),
+				'color' => 'orange',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				sprintf(
+					/* translators: %s: the wp_service_worker_navigation_preload filter call */
+					esc_html__( 'A theme or a plugin appears to have disabled navigation preload in order to enable a navigation caching strategy. This was a workaround that is now no longer needed, and it is actually being ignored. Remove the following code from your theme/plugin to improve performance: %s.', 'pwa' ),
+					'<code>add_filter( \'wp_service_worker_navigation_preload\', \'__return_false\' </code>'
+				)
+			),
+			'actions'     => sprintf(
+				'<a href="https://developers.google.com/web/tools/workbox/modules/workbox-navigation-preload#who_should_enable_navigation_preloads">%s</a>',
+				esc_html__( 'Learn about enabling navigation preload.', 'pwa' )
+			),
+		);
 	}
-	?>
-	<div class="notice notice-warning">
-		<p>
-			<?php
-			printf(
-				/* translators: %s: the wp_service_worker_navigation_preload filter call */
-				__( '<strong>PWA:</strong> Your theme or a plugin appears to have disabled navigation preload in order to enable a navigation caching stragegy. This was a workaround that is now no longer needed. Remove the following code from your theme/plugin to improve performance: <code>%s</code>.', 'pwa' ), // phpcs:ignore WordPress.Security.EscapeOutput
-				'add_filter( \'wp_service_worker_navigation_preload\', \'__return_false\' )'
-			);
-			?>
-		</p>
-	</div>
-	<?php
+
+	$result['test'] = 'navigation_preload_enabled';
+
+	return $result;
 }
-add_action( 'admin_notices', '_pwa_print_disabled_navigation_preload_notice' );
 
 /** WP_Web_App_Manifest Class */
 require_once PWA_PLUGIN_DIR . '/wp-includes/class-wp-web-app-manifest.php';

--- a/readme.md
+++ b/readme.md
@@ -237,7 +237,8 @@ add_filter( 'wp_service_worker_navigation_caching_strategy_args', function( $arg
 👉 If you previously added a `wp_service_worker_navigation_preload` filter to disable navigation preload,
 you should probably remove it. This was originally needed to work around an issue with ensuring the offline
 page would work when using a navigation caching strategy, but it is no longer needed and it should be removed
-improved performance. Disabling navigation preload is only relevant when you are developing an app shell.
+[improved performance](https://developers.google.com/web/updates/2017/02/navigation-preload). Disabling navigation
+preload is only relevant when you are developing an app shell.
 
 ### Offline / 500 error handling ###
 The feature plugins offers improved offline experience by displaying a custom template when user is offline instead of the default message in browser. Same goes for 500 errors -- a template is displayed together with error details.

--- a/readme.md
+++ b/readme.md
@@ -223,8 +223,6 @@ wp_register_service_worker_precaching_route(
 If you would like to opt-in to a caching strategy for navigation requests, you can do:
 
 ```php
-add_filter( 'wp_service_worker_navigation_preload', '__return_false' );
-
 add_filter( 'wp_service_worker_navigation_caching_strategy', function() {
 	return WP_Service_Worker_Caching_Routes::STRATEGY_STALE_WHILE_REVALIDATE;
 } );
@@ -235,6 +233,11 @@ add_filter( 'wp_service_worker_navigation_caching_strategy_args', function( $arg
 	return $args;
 } );
 ```
+
+👉 If you previously added a `wp_service_worker_navigation_preload` filter to disable navigation preload,
+you should probably remove it. This was originally needed to work around an issue with ensuring the offline
+page would work when using a navigation caching strategy, but it is no longer needed and it should be removed
+improved performance. Disabling navigation preload is only relevant when you are developing an app shell.
 
 ### Offline / 500 error handling ###
 The feature plugins offers improved offline experience by displaying a custom template when user is offline instead of the default message in browser. Same goes for 500 errors -- a template is displayed together with error details.

--- a/readme.txt
+++ b/readme.txt
@@ -236,7 +236,8 @@ add_filter( 'wp_service_worker_navigation_caching_strategy_args', function( $arg
 👉 If you previously added a `wp_service_worker_navigation_preload` filter to disable navigation preload,
 you should probably remove it. This was originally needed to work around an issue with ensuring the offline
 page would work when using a navigation caching strategy, but it is no longer needed and it should be removed
-improved performance. Disabling navigation preload is only relevant when you are developing an app shell.
+[improved performance](https://developers.google.com/web/updates/2017/02/navigation-preload). Disabling navigation
+preload is only relevant when you are developing an app shell.
 
 = Offline / 500 error handling =
 The feature plugins offers improved offline experience by displaying a custom template when user is offline instead of the default message in browser. Same goes for 500 errors -- a template is displayed together with error details.

--- a/readme.txt
+++ b/readme.txt
@@ -222,8 +222,6 @@ wp_register_service_worker_precaching_route(
 If you would like to opt-in to a caching strategy for navigation requests, you can do:
 
 <pre lang="php">
-add_filter( 'wp_service_worker_navigation_preload', '__return_false' );
-
 add_filter( 'wp_service_worker_navigation_caching_strategy', function() {
 	return WP_Service_Worker_Caching_Routes::STRATEGY_STALE_WHILE_REVALIDATE;
 } );
@@ -234,6 +232,11 @@ add_filter( 'wp_service_worker_navigation_caching_strategy_args', function( $arg
 	return $args;
 } );
 </pre>
+
+👉 If you previously added a `wp_service_worker_navigation_preload` filter to disable navigation preload,
+you should probably remove it. This was originally needed to work around an issue with ensuring the offline
+page would work when using a navigation caching strategy, but it is no longer needed and it should be removed
+improved performance. Disabling navigation preload is only relevant when you are developing an app shell.
 
 = Offline / 500 error handling =
 The feature plugins offers improved offline experience by displaying a custom template when user is offline instead of the default message in browser. Same goes for 500 errors -- a template is displayed together with error details.

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -92,7 +92,7 @@ class WP_Service_Workers implements WP_Service_Worker_Registry_Aware {
 	 */
 	public function serve_request() {
 		// See wp_debug_mode() for how this is also done for REST API responses.
-		@ini_set( 'display_errors', 0 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set
+		@ini_set( 'display_errors', 0 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set, WordPress.PHP.IniSet.display_errors_Blacklisted
 
 		/*
 		 * Per Workbox <https://developers.google.com/web/tools/workbox/guides/service-worker-checklist#cache-control_of_your_service_worker_file>:

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -91,6 +91,9 @@ class WP_Service_Workers implements WP_Service_Worker_Registry_Aware {
 	 * @see wp_service_worker_loaded()
 	 */
 	public function serve_request() {
+		// See wp_debug_mode() for how this is also done for REST API responses.
+		@ini_set( 'display_errors', 0 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set
+
 		/*
 		 * Per Workbox <https://developers.google.com/web/tools/workbox/guides/service-worker-checklist#cache-control_of_your_service_worker_file>:
 		 * "Generally, most developers will want to set the Cache-Control header to no-cache,

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -114,42 +114,6 @@ class WP_Service_Worker_Configuration_Component implements WP_Service_Worker_Com
 			}
 		}
 
-		/**
-		 * Filters whether navigation preload is enabled.
-		 *
-		 * The filtered value will be sent as the Service-Worker-Navigation-Preload header value if a truthy string.
-		 * This filter should be set to return false to disable navigation preload such as when a site is using
-		 * the app shell model. Take care of the current scope when setting this, as it is unlikely that the admin
-		 * should have navigation preload disabled until core has an admin single-page app. To disable navigation preload on
-		 * the frontend only, you may do:
-		 *
-		 *     add_filter( 'wp_front_service_worker', function() {
-		 *         add_filter( 'wp_service_worker_navigation_preload', '__return_false' );
-		 *     } );
-		 *
-		 * Alternatively, you should check the `$current_scope` for example:
-		 *
-		 *     add_filter( 'wp_service_worker_navigation_preload', function( $preload, $current_scope ) {
-		 *         if ( WP_Service_Workers::SCOPE_FRONT === $current_scope ) {
-		 *             $preload = false;
-		 *         }
-		 *         return $preload;
-		 *     }, 10, 2 );
-		 *
-		 * @param bool|string $navigation_preload Whether to use navigation preload. Returning a string will cause it it to populate the Service-Worker-Navigation-Preload header.
-		 * @param int         $current_scope      The current scope. Either 1 (WP_Service_Workers::SCOPE_FRONT) or 2 (WP_Service_Workers::SCOPE_ADMIN).
-		 */
-		$navigation_preload = apply_filters( 'wp_service_worker_navigation_preload', true, $current_scope );
-		if ( false !== $navigation_preload ) {
-			if ( is_string( $navigation_preload ) ) {
-				$script .= sprintf( "workbox.navigationPreload.enable( %s );\n", wp_service_worker_json_encode( $navigation_preload ) );
-			} else {
-				$script .= "workbox.navigationPreload.enable();\n";
-			}
-		} else {
-			$script .= "workbox.navigationPreload.disable();\n";
-		}
-
 		// Note: This includes the aliasing of `workbox` to `wp.serviceWorker`.
 		$script .= file_get_contents( PWA_PLUGIN_DIR . '/wp-includes/js/service-worker.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -499,7 +499,10 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 			}
 		}
 		if ( ! empty( $navigation_route_precache_entry['url'] ) ) {
-			$scripts->precaching_routes()->register( $navigation_route_precache_entry['url'], isset( $navigation_route_precache_entry['revision'] ) ? $navigation_route_precache_entry['revision'] : null );
+			$scripts->precaching_routes()->register(
+				$navigation_route_precache_entry['url'],
+				isset( $navigation_route_precache_entry['revision'] ) ? $navigation_route_precache_entry['revision'] : null
+			);
 		}
 
 		// Streaming.
@@ -525,14 +528,63 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 			 */
 			$streaming_header_precache_entry = apply_filters( 'wp_streaming_header_precache_entry', $streaming_header_precache_entry );
 
-			if ( $streaming_header_precache_entry ) {
+			if ( ! empty( $streaming_header_precache_entry['url'] ) ) {
 				$scripts->precaching_routes()->register( $streaming_header_precache_entry['url'], isset( $streaming_header_precache_entry['revision'] ) ? $streaming_header_precache_entry['revision'] : null );
+			}
+		}
 
-				add_filter( 'wp_service_worker_navigation_preload', '__return_false' ); // Navigation preload and streaming don't mix!
+		if ( ! empty( $streaming_header_precache_entry['url'] ) || ! empty( $navigation_route_precache_entry['url'] ) ) {
+			/*
+			 * App shell is mutually exclusive with navigation preload.
+			 * Likewise, navigation preload doesn't mix with streaming.
+			 */
+			$navigation_preload = false;
+		} else {
+			/**
+			 * Filters whether navigation preload is enabled.
+			 *
+			 * The filtered value will be sent as the Service-Worker-Navigation-Preload header value if a truthy string.
+			 * This filter should be set to return false to disable navigation preload such as when a site is using
+			 * the app shell model, but in practice this filter does not need to be used because by supplying a
+			 * navigation route via the wp_service_worker_navigation_route filter, then the navigation preload will
+			 * automatically be set to false. Take care of the current scope when setting this, as it is unlikely that the admin
+			 * should have navigation preload disabled until core has an admin single-page app. To disable navigation preload on
+			 * the frontend only, you may do:
+			 *
+			 *     add_filter( 'wp_front_service_worker', function() {
+			 *         add_filter( 'wp_service_worker_navigation_preload', '__return_false' );
+			 *     } );
+			 *
+			 * Alternatively, you should check the `$current_scope` for example:
+			 *
+			 *     add_filter( 'wp_service_worker_navigation_preload', function( $preload, $current_scope ) {
+			 *         if ( WP_Service_Workers::SCOPE_FRONT === $current_scope ) {
+			 *             $preload = false;
+			 *         }
+			 *         return $preload;
+			 *     }, 10, 2 );
+			 *
+			 * @param bool|string $navigation_preload Whether to use navigation preload. Returning a string will cause it it to populate the Service-Worker-Navigation-Preload header.
+			 * @param int         $current_scope      The current scope. Either 1 (WP_Service_Workers::SCOPE_FRONT) or 2 (WP_Service_Workers::SCOPE_ADMIN).
+			 */
+			$navigation_preload = apply_filters( 'wp_service_worker_navigation_preload', true, wp_service_workers()->get_current_scope() );
+
+			if ( WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY !== $caching_strategy && false === $navigation_preload ) {
+				$navigation_preload = true;
+				_doing_it_wrong(
+					'add_filter',
+					sprintf(
+						/* translators: %s is the wp_service_worker_navigation_preload filter name */
+						esc_html__( 'PWA: Navigation preload should not be disabled via the %s filter when using a navigation caching strategy.', 'pwa' ),
+						'wp_service_worker_navigation_preload'
+					),
+					'0.3'
+				);
 			}
 		}
 
 		$this->replacements = array(
+			'NAVIGATION_PRELOAD'               => wp_service_worker_json_encode( $navigation_preload ),
 			'CACHING_STRATEGY'                 => wp_service_worker_json_encode( $caching_strategy ),
 			'CACHING_STRATEGY_ARGS'            => isset( $caching_strategy_args_js ) ? $caching_strategy_args_js : '{}',
 			'NAVIGATION_ROUTE_ENTRY'           => wp_service_worker_json_encode( $navigation_route_precache_entry ),

--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -1,12 +1,24 @@
-/* global CACHING_STRATEGY, CACHING_STRATEGY_ARGS, NAVIGATION_ROUTE_ENTRY,
+/* global NAVIGATION_PRELOAD, CACHING_STRATEGY, CACHING_STRATEGY_ARGS, NAVIGATION_ROUTE_ENTRY,
 ERROR_OFFLINE_URL, ERROR_500_URL, SHOULD_STREAM_RESPONSE, STREAM_HEADER_FRAGMENT_URL, ERROR_500_BODY_FRAGMENT_URL,
 ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BLACKLIST_PATTERNS, ERROR_MESSAGES */
 
 // IIFE is used for lexical scoping instead of just a braces block due to bug with const in Safari.
 ( () => {
+	const navigationPreload = NAVIGATION_PRELOAD;
 	const isStreamingResponses = SHOULD_STREAM_RESPONSE && wp.serviceWorker.streams.isSupported();
 	const errorMessages = ERROR_MESSAGES;
 	const navigationRouteEntry = NAVIGATION_ROUTE_ENTRY;
+
+	// Configure navigation preload.
+	if ( false !== navigationPreload ) {
+		if ( typeof navigationPreload === 'string' ) {
+			wp.serviceWorker.navigationPreload.enable( navigationPreload );
+		} else {
+			wp.serviceWorker.navigationPreload.enable();
+		}
+	} else {
+		wp.serviceWorker.navigationPreload.disable();
+	}
 
 	/**
 	 * Handle navigation request.

--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -118,23 +118,6 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 			} );
 		};
 
-		/*
-		 * If navigation preload is enabled, use the preload request instead of doing another fetch.
-		 * This prevents requests from being duplicated. See <https://github.com/xwp/pwa-wp/issues/67>.
-		 */
-		if ( event.preloadResponse ) {
-			try {
-				const response = await event.preloadResponse;
-				if ( response ) {
-					responsePreloaded = true;
-					return handleResponse( response );
-				}
-			} catch ( error ) {
-				responsePreloaded = true;
-				return sendOfflineResponse();
-			}
-		}
-
 		const navigationCacheStrategy = new wp.serviceWorker.strategies[ CACHING_STRATEGY ]( CACHING_STRATEGY_ARGS );
 
 		if ( canStreamResponse() ) {
@@ -170,7 +153,7 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 
 			return stream.response;
 		} else {
-			return navigationCacheStrategy.makeRequest( { request: event.request } )
+			return navigationCacheStrategy.handle( { event, request: event.request } )
 				.then( handleResponse )
 				.catch( sendOfflineResponse );
 		}

--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -36,10 +36,8 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 	 * @return {Promise<Response>} Response.
 	 */
 	async function handleNavigationRequest( { event } ) {
-		let responsePreloaded = false;
-
 		const canStreamResponse = () => {
-			return isStreamingResponses && ! responsePreloaded;
+			return isStreamingResponses && ! navigationPreload;
 		};
 
 		const handleResponse = ( response ) => {

--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -20,6 +20,15 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 		wp.serviceWorker.navigationPreload.disable();
 	}
 
+	/*
+	 * Define strategy up front so that Workbox modules will import at install time.
+	 * If this is not done, then an error will happen like:
+	 * > Unable to import module 'workbox-expiration'
+	 * Along with an exception:
+	 * > workbox-sw.js:1 Uncaught (in promise) DOMException: Failed to execute 'importScripts' on 'WorkerGlobalScope'
+	 */
+	const navigationCacheStrategy = new wp.serviceWorker.strategies[ CACHING_STRATEGY ]( CACHING_STRATEGY_ARGS );
+
 	/**
 	 * Handle navigation request.
 	 *
@@ -129,8 +138,6 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 				} );
 			} );
 		};
-
-		const navigationCacheStrategy = new wp.serviceWorker.strategies[ CACHING_STRATEGY ]( CACHING_STRATEGY_ARGS );
 
 		if ( canStreamResponse() ) {
 			const streamHeaderFragmentURL = STREAM_HEADER_FRAGMENT_URL;


### PR DESCRIPTION
Revisits #80/#67.

At the moment, when trying to enable a navigation request caching strategy (e.g. Network-First or Stale-While-Revalidate) you also have to disable navigation preload in order to successfully get the cached pages to be served instead of the offline page:

> <img width="800" alt="before-when-navigation-preload-enabled" src="https://user-images.githubusercontent.com/134745/60184587-99535580-9828-11e9-8051-41137dcaf354.png">

Navigation preload was developed to [improve performance of navigation requests](https://developers.google.com/web/updates/2017/02/navigation-preload) while the service worker is not booted.

The problem came down to incorrectly using `strategy.makeRequest()` when it should have been using `strategy.handle()`.

# Testing

Given a theme that has the following configuration for the service worker to enable a Network-First caching strategy for navigation requests:

```php
/*
 * Opt-in to Network-First caching strategy for navigation requests so that once you visit a page, you can go back to
 * that page even when you are offline, even when restarting the browser or reloading the page.
 */
add_filter(
	'wp_service_worker_navigation_caching_strategy',
	function() {
		return WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST;
	}
);

/*
 * Configure navigation request caching by limiting it to 50 entries and using the cache named 'pages'.
 * See https://github.com/xwp/pwa-wp/issues/176 for where something like this should be provided by default.
 */
add_filter(
	'wp_service_worker_navigation_caching_strategy_args',
	function( $args ) {
		$args['cacheName']                           = 'pages';
		$args['plugins']['expiration']['maxEntries'] = 50;
		return $args;
	}
);
```

## Before

Preload is not being used:

<img width="932" alt="after wp_service_worker_navigation_preload_false (disabled)" src="https://user-images.githubusercontent.com/134745/60184749-e505ff00-9828-11e9-8964-0540a5cc46be.png">

🚫 Offline page always displays even though it has been cached using the navigation caching strategy.

## After

Preload _is_ being used:

<img width="932" alt="after wp_service_worker_navigation_preload_true (enabled)" src="https://user-images.githubusercontent.com/134745/60185058-89884100-9829-11e9-81d5-de2acb7fc7df.png">

✅ Cached pages are displayed.

Additionally, an admin notice is added to help guide users to correct usage given that the `readme` was incorrect:

![image](https://user-images.githubusercontent.com/134745/60185727-b557f680-982a-11e9-9eaf-7b9fe71d6d03.png)

Even if the user does nothing, the navigation preload will be forced to be `true`, though a `_doing_it_wrong()` will be logged. Also, Site Health will inform of the navigation preload status. When it is being erroneously disabled:

<img width="877" alt="Screen Shot 2019-07-18 at 16 31 48" src="https://user-images.githubusercontent.com/134745/61493955-8260d880-a97a-11e9-9283-0090da1c39f6.png">

And when it is left enabled, with test passing:

<img width="826" alt="Screen Shot 2019-07-18 at 16 39 30" src="https://user-images.githubusercontent.com/134745/61493999-a3c1c480-a97a-11e9-9c38-d5e76a06dd23.png">

Lastly, when calling `\WP_Service_Workers::serve_request()` it will turn off `display_errors` to prevent debug messages from causing JS syntax errors in the service worker; this is what is done in the WP REST API as well.