### PR TITLE
Skip installation of service worker from post embed iframe

### DIFF
--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -8,7 +8,7 @@
  */
 
 // Ensure service workers are printed on frontend, admin, Customizer, login, sign-up, and activate pages.
-foreach ( array( 'wp_print_scripts', 'admin_print_scripts', 'customize_controls_print_scripts', 'login_footer', 'after_signup_form', 'activate_wp_head' ) as $filter ) {
+foreach ( array( 'wp_print_footer_scripts', 'admin_print_scripts', 'customize_controls_print_scripts', 'login_footer', 'after_signup_form', 'activate_wp_head' ) as $filter ) {
 	add_filter( $filter, 'wp_print_service_workers', 9 );
 }
 

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -110,6 +110,18 @@ function wp_get_service_worker_url( $scope = WP_Service_Workers::SCOPE_FRONT ) {
  * @since 0.1
  */
 function wp_print_service_workers() {
+	/*
+	 * Skip installing service worker from context of post embed iframe, as the post embed iframe does not need the
+	 * service worker. Also, installation via post embed iframe could be seen to be somewhat sneaky. Lastly, if the
+	 * post embed is on the same site and contained iframe is sandbox without allow-same-origin, then the service
+	 * worker will fail to install with an exception:
+	 * > Uncaught DOMException: Failed to read the 'serviceWorker' property from 'Navigator': Service worker is
+	 * > disabled because the context is sandboxed and lacks the 'allow-same-origin' flag.
+	 */
+	if ( is_embed() ) {
+		return;
+	}
+
 	global $pagenow;
 	$scopes = array();
 


### PR DESCRIPTION
Skip installing service worker from context of post embed iframe, as the post embed iframe does not need the service worker. Also, installation via post embed iframe could be seen to be somewhat sneaky. Lastly, if the post embed is on the same site and contained iframe is sandbox without allow-same-origin, then the service worker will fail to install with an exception:

> Uncaught DOMException: Failed to read the 'serviceWorker' property from 'Navigator': Service worker is disabled because the context is sandboxed and lacks the 'allow-same-origin' flag.

<img width="940" alt="Screen Shot 2019-06-30 at 18 33 54" src="https://user-images.githubusercontent.com/134745/60405639-57971780-9b66-11e9-817e-48f6cde44142.png">

This PR also moves SW installation from the head to the footer.