### PR TITLE
Only use enqueued scripts/style handles in revision

### DIFF
--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -334,19 +334,7 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 			$revision .= ';nav=' . $this->get_nav_menu_locations_hash();
 
 			// Include all scripts and styles in revision.
-			$enqueued_scripts = array();
-			foreach ( wp_scripts()->queue as $handle ) {
-				if ( isset( wp_scripts()->registered[ $handle ] ) ) {
-					$enqueued_scripts[ $handle ] = wp_scripts()->registered[ $handle ];
-				}
-			}
-			$enqueued_styles = array();
-			foreach ( wp_styles()->queue as $handle ) {
-				if ( isset( wp_styles()->registered[ $handle ] ) ) {
-					$enqueued_styles[ $handle ] = wp_styles()->registered[ $handle ];
-				}
-			}
-			$revision .= ';deps=' . md5( wp_json_encode( compact( 'enqueued_scripts', 'enqueued_styles' ) ) );
+			$revision .= ';deps=' . md5( wp_json_encode( array( wp_scripts()->queue, wp_styles()->queue ) ) );
 
 			// @todo Allow different routes to have varying caching strategies?
 


### PR DESCRIPTION
When skip-waiting is not disabled (which it is not by default) whenever the logic in the service worker changes in any way, the page is reloaded when the new service worker is installed. The offline and 500 error templates use the enqueued scripts/styles as part of the precache entry revision. The problem is that the revision was including the entire script/style dependency objects which include the `ver`. If a theme enqueues a script or style and uses `time()` as the `ver` then this will result in the service worker JS changing every time it is accessed, and thus the page will infinitely reload. This is known to be an issue with the Genesis Sample theme.

In reality only the list of handles should need to be included, so this change is applied here.  

Fixes #183.