### PR TITLE
Prevent needless wordpress_sw_installed cookie from being set outside the wp-admin

### DIFF
--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -163,7 +163,7 @@ function wp_print_service_workers() {
 							<?php echo wp_json_encode( compact( 'scope' ) ); ?>
 						).then( reg => {
 							<?php if ( WP_Service_Workers::SCOPE_ADMIN === $name ) : ?>
-								document.cookie = 'wordpress_sw_installed=1; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT; secure; samesite=strict';
+								document.cookie = <?php echo wp_json_encode( sprintf( 'wordpress_sw_installed=1; path=%s; expires=Fri, 31 Dec 9999 23:59:59 GMT; secure; samesite=strict', $scope ) ); ?>;
 							<?php endif; ?>
 							<?php if ( ! wp_service_worker_skip_waiting() ) : ?>
 								reg.addEventListener( 'updatefound', () => {

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -162,7 +162,9 @@ function wp_print_service_workers() {
 							<?php echo wp_json_encode( wp_get_service_worker_url( $name ) ); ?>,
 							<?php echo wp_json_encode( compact( 'scope' ) ); ?>
 						).then( reg => {
-							document.cookie = 'wordpress_sw_installed=1; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT; secure; samesite=strict';
+							<?php if ( WP_Service_Workers::SCOPE_ADMIN === $name ) : ?>
+								document.cookie = 'wordpress_sw_installed=1; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT; secure; samesite=strict';
+							<?php endif; ?>
 							<?php if ( ! wp_service_worker_skip_waiting() ) : ?>
 								reg.addEventListener( 'updatefound', () => {
 									if ( ! reg.installing ) {


### PR DESCRIPTION
Fixes #188.

The `wordpress_sw_installed` cookie is only used to disable `$concatenate_scripts` so it is only needed when installing the admin service worker. This PR limits the cookie to the admin and ensures the cookie path matches the admin scope:

![image](https://user-images.githubusercontent.com/134745/60631207-39722700-9db3-11e9-8860-485126545879.png)
