### PR TITLE
Differentiate between client and server being offline

### DIFF
--- a/wp-admin/error.php
+++ b/wp-admin/error.php
@@ -15,12 +15,14 @@ header( 'X-Robots-Tag: noindex' );
 switch ( isset( $_REQUEST['code'] ) ? sanitize_key( $_REQUEST['code'] ) : null ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.NoNonceVerification
 	case 'offline':
 		$title_prefix = __( 'Offline', 'pwa' );
-		$content      = sprintf( '<h1>%s</h1>', esc_html__( 'You seem to be offline.', 'pwa' ) );
-		$content     .= sprintf( '<p>%s</p>', esc_html__( 'Please check your internet connection. In the future, this error screen could provide you with actions you can perform while offline, like edit recent drafts in Gutenberg.', 'pwa' ) );
+		$content      = sprintf( '<h1>%s</h1>', esc_html__( 'Offline', 'pwa' ) );
+		$content     .= '<p><!--WP_SERVICE_WORKER_ERROR_MESSAGE--></p>';
+		$content     .= sprintf( '<p>%s</p>', esc_html__( 'In the future, this error screen could provide you with actions you can perform while offline, like edit recent drafts in Gutenberg.', 'pwa' ) );
 		break;
 	case '500':
 		$title_prefix = __( 'Internal Server Error', 'pwa' );
 		$content      = sprintf( '<h1>%s</h1>', esc_html__( 'A server error occurred.', 'pwa' ) );
+		$content     .= '<p><!--WP_SERVICE_WORKER_ERROR_MESSAGE--></p>';
 		$content     .= sprintf(
 			'<p>%s</p>',
 			esc_html__( 'Something went wrong which prevented WordPress from serving a response. Please check your error logs.', 'pwa' )

--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -91,7 +91,6 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 								return details;
 							}
 						);
-
 						return new Response( body, init );
 					} );
 				} );
@@ -111,7 +110,7 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 						headers: response.headers
 					};
 
-					const body = text.replace( /[<]!--WP_SERVICE_WORKER_ERROR_MESSAGE-->/, errorMessages.default );
+					const body = text.replace( /[<]!--WP_SERVICE_WORKER_ERROR_MESSAGE-->/, navigator.onLine ? errorMessages.serverOffline : errorMessages.clientOffline );
 
 					return new Response( body, init );
 				} );

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -138,9 +138,10 @@ function wp_service_worker_get_error_messages() {
 	return apply_filters(
 		'wp_service_worker_error_messages',
 		array(
-			'default' => __( 'Please check your internet connection, and try again.', 'pwa' ),
-			'error'   => __( 'Something prevented the page from being rendered. Please try again.', 'pwa' ),
-			'comment' => __( 'Your comment will be submitted once you are back online!', 'pwa' ),
+			'clientOffline' => __( 'It seems you are offline. Please check your internet connection and try again.', 'pwa' ),
+			'serverOffline' => __( 'The server appears to be down. Please try again later.', 'pwa' ),
+			'error'         => __( 'Something prevented the page from being rendered. Please try again.', 'pwa' ),
+			'comment'       => __( 'Your comment will be submitted once you are back online!', 'pwa' ),
 		)
 	);
 }

--- a/wp-includes/theme-compat/offline.php
+++ b/wp-includes/theme-compat/offline.php
@@ -14,7 +14,7 @@ pwa_get_header( 'error' );
 
 ?>
 <main>
-	<h1><?php esc_html_e( 'Oops! It looks like you&#8217;re offline.', 'pwa' ); ?></h1>
+	<h1><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
 	<?php wp_service_worker_error_message_placeholder(); ?>
 </main>
 <?php


### PR DESCRIPTION
Fixes #177. The offline template can be served both when the client is offline and when the server is down. Both of these conditions were being communicated as the client being offline. This PR helps ensure that a server-down message is displayed when failing to fetch the requested page but the user's connection is still `onLine`.

# Admin

## Client offline (internet down)

<img width="802" alt="admin-client-offline" src="https://user-images.githubusercontent.com/134745/60780501-93485900-a0f3-11e9-81d1-42b20e96cd5a.png">

## Server down

<img width="796" alt="admin-server-offline" src="https://user-images.githubusercontent.com/134745/60780493-8d527800-a0f3-11e9-8958-44a7f6266872.png">

# Frontend


## Client offline (internet down)

<img width="796" alt="front-client-offline" src="https://user-images.githubusercontent.com/134745/60780518-a4916580-a0f3-11e9-9f2d-2978ba2cd5c6.png">

## Server down

<img width="802" alt="front-server-offline" src="https://user-images.githubusercontent.com/134745/60780520-a824ec80-a0f3-11e9-8eee-6b2eef85109c.png">


