### PR TITLE
Guard against causing Workbox to call importScripts() after SW installation

### DIFF
--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -8,6 +8,15 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 	const errorMessages = ERROR_MESSAGES;
 	const navigationRouteEntry = NAVIGATION_ROUTE_ENTRY;
 
+	/*
+	 * Define strategy up front so that Workbox modules will import at install time.
+	 * If this is not done, then an error will happen like:
+	 * > Unable to import module 'workbox-expiration'
+	 * Along with an exception:
+	 * > workbox-sw.js:1 Uncaught (in promise) DOMException: Failed to execute 'importScripts' on 'WorkerGlobalScope'
+	 */
+	const navigationCacheStrategy = new wp.serviceWorker.strategies[ CACHING_STRATEGY ]( CACHING_STRATEGY_ARGS );
+
 	/**
 	 * Handle navigation request.
 	 *
@@ -133,8 +142,6 @@ ERROR_OFFLINE_BODY_FRAGMENT_URL, STREAM_HEADER_FRAGMENT_QUERY_VAR, NAVIGATION_BL
 				return sendOfflineResponse();
 			}
 		}
-
-		const navigationCacheStrategy = new wp.serviceWorker.strategies[ CACHING_STRATEGY ]( CACHING_STRATEGY_ARGS );
 
 		if ( canStreamResponse() ) {
 			const streamHeaderFragmentURL = STREAM_HEADER_FRAGMENT_URL;


### PR DESCRIPTION
Cherry-picking 6b6d819 from #178.

See https://www.chromestatus.com/feature/5748516353736704

This is necessary because Workbox lazy-loads modules as they are used.