### PR TITLE
 Eliminate auto-derived short_name from manifest since not reliable

### DIFF
--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -134,13 +134,11 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 		update_option( 'blogname', $blogname );
 		$actual_manifest = $this->instance->get_manifest();
 
-		preg_match( '/^.{0,12}(?= |$)/', $blogname, $short_name_matches );
 		$expected_manifest = array(
 			'background_color' => WP_Web_App_Manifest::FALLBACK_THEME_COLOR,
 			'description'      => get_bloginfo( 'description' ),
 			'display'          => 'minimal-ui',
 			'name'             => $blogname,
-			'short_name'       => $short_name_matches[0],
 			'lang'             => get_bloginfo( 'language' ),
 			'dir'              => is_rtl() ? 'rtl' : 'ltr',
 			'start_url'        => get_home_url(),

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -128,19 +128,6 @@ class WP_Web_App_Manifest {
 			$manifest['lang'] = $language;
 		}
 
-		/**
-		 * Gets the 'short_name' by limiting the blog name to 12 characters.
-		 * And if this cuts off a word, it omits the word entirely by using a positive look-ahead in the regex.
-		 * For example, the first 12 characters of 'My PWA WordPress Site' are 'My PWA WordP'.
-		 * Because this cuts off the last word, this removes 'WordP' entirely: 'My PWA'.
-		 *
-		 * @link https://stackoverflow.com/questions/12646197/cut-the-string-to-be-80-characters-and-must-keep-the-words-without-cutting-th#answer-12646400
-		 */
-		preg_match( '/^.{0,12}(?= |$)/', $manifest['name'], $short_name_matches );
-		if ( $short_name_matches ) {
-			$manifest['short_name'] = $short_name_matches[0];
-		}
-
 		$theme_color = $this->get_theme_color();
 		if ( $theme_color ) {
 			$manifest['background_color'] = $theme_color;


### PR DESCRIPTION
Fixes #181.
Closes #200.
Related #168.

Also improves robustness of `\Test_WP_HTTPS_UI::test_filter_site_url_and_home()` to account for case where `WP_HOME` is set, and to ensure `site_url()` and `home_url()` are both accounted for.