### PR TITLE
Automatically copy name to short_name in web app manifest if not greater than 12 characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 addons:
   apt:
     packages:

--- a/pwa.php
+++ b/pwa.php
@@ -118,7 +118,7 @@ function _pwa_add_disabled_navigation_preload_site_status_test( $tests ) {
 add_filter( 'site_status_tests', '_pwa_add_disabled_navigation_preload_site_status_test' );
 
 /**
- * Print admin notice when a build has not been been performed.
+ * Flag navigation preload incorrectly being disabled.
  *
  * This is temporary measure to correct a mistake in the example for how navigation request caching strategies.
  *

--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -130,7 +130,7 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 	 */
 	public function test_get_manifest() {
 		$this->mock_site_icon();
-		$blogname = "PWA's Domain Is Here";
+		$blogname = 'PWA Test';
 		update_option( 'blogname', $blogname );
 		$actual_manifest = $this->instance->get_manifest();
 
@@ -139,6 +139,7 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 			'description'      => get_bloginfo( 'description' ),
 			'display'          => 'minimal-ui',
 			'name'             => $blogname,
+			'short_name'       => $blogname,
 			'lang'             => get_bloginfo( 'language' ),
 			'dir'              => is_rtl() ? 'rtl' : 'ltr',
 			'start_url'        => home_url( '/' ),
@@ -146,6 +147,13 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 			'icons'            => $this->instance->get_icons(),
 		);
 		$this->assertEquals( $expected_manifest, $actual_manifest );
+
+		// Check that long names do not automatically copy to short name.
+		$blogname = str_repeat( 'x', 13 );
+		update_option( 'blogname', $blogname );
+		$actual_manifest = $this->instance->get_manifest();
+		$this->assertEquals( $blogname, $actual_manifest['name'] );
+		$this->assertArrayNotHasKey( 'short_name', $actual_manifest );
 
 		// Test that the filter at the end of the method overrides the value.
 		add_filter( 'web_app_manifest', array( $this, 'mock_manifest' ) );

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -123,6 +123,19 @@ class WP_Web_App_Manifest {
 			'display'   => 'minimal-ui',
 			'dir'       => is_rtl() ? 'rtl' : 'ltr',
 		);
+
+		/*
+		 * If the name is 12 characters or less, use it as the short_name. Lighthouse complains when the short_name
+		 * is absent, even when the name is 12 characters or less. Chrome's max recommended short_name length is 12
+		 * characters.
+		 *
+		 * https://developers.google.com/web/tools/lighthouse/audits/manifest-contains-short_name
+		 * https://developer.chrome.com/apps/manifest/name#short_name
+		 */
+		if ( strlen( $manifest['name'] ) <= 12 ) {
+			$manifest['short_name'] = $manifest['name'];
+		}
+
 		$language = get_bloginfo( 'language' );
 		if ( $language ) {
 			$manifest['lang'] = $language;

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -206,14 +206,23 @@ class WP_Web_App_Manifest {
 	public function test_short_name_present_in_manifest() {
 		$manifest = $this->get_manifest();
 
-		/* translators: %d is the max length as a number */
-		$description = sprintf( __( 'The <code>short_name</code> is a short version of your website&#8217;s name which is displayed when there is not enough space for the full name, for example with the site icon on a phone&#8217;s homescreen. It should be a maximum of %d characters long.', 'pwa' ), self::SHORT_NAME_MAX_LENGTH );
+		$description = sprintf(
+			/* translators: %1$s is `short_name`, %2$d is the max length as a number */
+			__( 'The %1$s is a short version of your website&#8217;s name. It is displayed when there is not enough space for the full name, for example with the site icon on a phone&#8217;s homescreen. It should be a maximum of %2$d characters long.', 'pwa' ),
+			'<code>short_name</code>',
+			self::SHORT_NAME_MAX_LENGTH
+		);
 
-		$actions = __( 'You currently may use <code>web_app_manifest</code> filter to set the short name, for example in your theme&#8217;s <code>functions.php</code>.', 'pwa' );
+		$actions = sprintf(
+			/* translators: %1$s is `web_app_manifest`, %2$s is `functions.php` */
+			__( 'You currently may use %1$s filter to set the short name, for example in your theme&#8217;s %2$s.', 'pwa' ),
+			'<code>web_app_manifest</code>',
+			'<code>functions.php</code>'
+		);
 
 		if ( empty( $manifest['short_name'] ) ) {
 			$result = array(
-				'label'       => __( 'Web App Manifest lacks a short_name entry', 'pwa' ),
+				'label'       => __( 'Web App Manifest lacks a short name entry', 'pwa' ),
 				'status'      => 'recommended',
 				'badge'       => array(
 					'label' => __( 'Progressive Web App', 'pwa' ),
@@ -227,7 +236,7 @@ class WP_Web_App_Manifest {
 				'label'       =>
 					sprintf(
 						/* translators: %1$s is the short name */
-						__( 'Web App Manifest has a short_name (%s) that is too long', 'pwa' ),
+						__( 'Web App Manifest has a short name (%s) that is too long', 'pwa' ),
 						esc_html( $manifest['short_name'] )
 					),
 				'status'      => 'recommended',
@@ -243,7 +252,7 @@ class WP_Web_App_Manifest {
 				'label'       =>
 					sprintf(
 						/* translators: %1$s is the short name */
-						__( 'Web App Manifest has a short_name (%s)', 'pwa' ),
+						__( 'Web App Manifest has a short name (%s)', 'pwa' ),
 						esc_html( $manifest['short_name'] )
 					),
 				'status'      => 'good',

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -36,6 +36,7 @@ class WP_Web_App_Manifest {
 	/**
 	 * Maximum length for short_name.
 	 *
+	 * @since 0.4
 	 * @link https://developers.google.com/web/tools/lighthouse/audits/manifest-contains-short_name
 	 * @link https://developer.chrome.com/apps/manifest/name#short_name
 	 * @var int
@@ -181,7 +182,7 @@ class WP_Web_App_Manifest {
 	/**
 	 * Register test for lacking short_name in web app manifest.
 	 *
-	 * @since 0.3.1
+	 * @since 0.4
 	 *
 	 * @param array $tests Tests.
 	 * @return array Tests.
@@ -197,7 +198,7 @@ class WP_Web_App_Manifest {
 	/**
 	 * Test that web app manifest contains a short_name.
 	 *
-	 * @since 0.3.1
+	 * @since 0.4
 	 * @todo Add test for PNG site icon.
 	 *
 	 * @return array Test results.


### PR DESCRIPTION
Lighthouse complains if there is no `short_name` even when the `name` is not greater than 12 characters:

<img width="735" alt="Screen Shot 2019-08-16 at 14 34 22" src="https://user-images.githubusercontent.com/134745/63201325-9d863d00-c039-11e9-8ee2-55ca841448bd.png">

This PR fixes that problem by copying the `name` as the `short_name` when it is not longer than 12 characters:

<img width="728" alt="Screen Shot 2019-08-16 at 14 36 44" src="https://user-images.githubusercontent.com/134745/63201342-b131a380-c039-11e9-9f2f-d72199f491f4.png">

# Site Health

Additionally, checks are added to site health.

<img width="819" alt="Screen Shot 2019-08-16 at 15 19 07" src="https://user-images.githubusercontent.com/134745/63201356-c27ab000-c039-11e9-98b5-b109ed891763.png">

<img width="815" alt="Screen Shot 2019-08-16 at 15 18 51" src="https://user-images.githubusercontent.com/134745/63201364-c9a1be00-c039-11e9-9ac0-729b6ee62c78.png">

<img width="817" alt="Screen Shot 2019-08-16 at 15 23 38" src="https://user-images.githubusercontent.com/134745/63201377-d8887080-c039-11e9-9593-eb3ed589f043.png">