### PR TITLE
Allow specifying HTTP method when registering a caching route

### DIFF
--- a/tests/components/test-class-wp-service-worker-caching-routes.php
+++ b/tests/components/test-class-wp-service-worker-caching-routes.php
@@ -49,11 +49,18 @@ class Test_WP_Service_Worker_Caching_Routes extends WP_UnitTestCase {
 			unset( $args['strategy'] );
 		}
 
+		$method = 'GET';
+		if ( isset( $args['method'] ) ) {
+			$method = $args['method'];
+			unset( $args['method'] );
+		}
+
 		$this->assertEqualSetsWithIndex(
 			array(
 				'route'         => $route,
 				'strategy'      => $strategy,
 				'strategy_args' => $args,
+				'method'        => $method,
 			),
 			array_pop( $routes )
 		);
@@ -98,6 +105,19 @@ class Test_WP_Service_Worker_Caching_Routes extends WP_UnitTestCase {
 				'/.*(?:gstatic)\.com.*$/',
 				array(
 					'strategy' => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_ONLY,
+				),
+			),
+			array(
+				'/api/.*\.json',
+				array(
+					'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST,
+					'cacheName' => 'my-api',
+					'method'    => 'POST',
+					'plugins'   => [
+						'expiration' => [
+							'maxAgeSeconds' => 60 * 60 * 24,
+						],
+					],
 				),
 			),
 		);

--- a/wp-includes/components/class-wp-service-worker-caching-routes-component.php
+++ b/wp-includes/components/class-wp-service-worker-caching-routes-component.php
@@ -83,11 +83,14 @@ class WP_Service_Worker_Caching_Routes_Component implements WP_Service_Worker_Co
 			// Ensure Workbox<=3 strategy factory names like "networkFirst" are converted to class names like "NetworkFirst".
 			$strategy = ucfirst( $route_data['strategy'] );
 
+			$method = isset( $route_data['method'] ) ? $route_data['method'] : 'GET';
+
 			$script .= sprintf(
-				'wp.serviceWorker.routing.registerRoute( new RegExp( %s ), new wp.serviceWorker.strategies[ %s ]( %s ) );',
+				"wp.serviceWorker.routing.registerRoute( new RegExp( %s ), new wp.serviceWorker.strategies[ %s ]( %s ), %s );\n",
 				wp_service_worker_json_encode( $route_data['route'] ),
 				wp_service_worker_json_encode( $strategy ),
-				WP_Service_Worker_Caching_Routes::prepare_strategy_args_for_js_export( $route_data['strategy_args'] )
+				WP_Service_Worker_Caching_Routes::prepare_strategy_args_for_js_export( $route_data['strategy_args'] ),
+				wp_service_worker_json_encode( $method )
 			);
 		}
 

--- a/wp-includes/components/class-wp-service-worker-caching-routes.php
+++ b/wp-includes/components/class-wp-service-worker-caching-routes.php
@@ -73,6 +73,7 @@ class WP_Service_Worker_Caching_Routes implements WP_Service_Worker_Registry {
 	 *                              WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST, WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_ONLY,
 	 *                              WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY.
 	 *     @type string $cache_name Name to use for the cache.
+	 *     @type string $method     HTTP method to cache. Defaults to 'GET'.
 	 *     @type array  $plugins    Array of plugins with configuration. The key of each plugin in the array must match the plugin's name.
 	 *                              See https://developers.google.com/web/tools/workbox/guides/using-plugins#workbox_plugins.
 	 * }
@@ -119,10 +120,17 @@ class WP_Service_Worker_Caching_Routes implements WP_Service_Worker_Registry {
 		$strategy = $args['strategy'];
 		unset( $args['strategy'] );
 
+		$method = 'GET';
+		if ( isset( $args['method'] ) ) {
+			$method = strtoupper( $args['method'] );
+			unset( $args['method'] );
+		}
+
 		$this->routes[] = array(
 			'route'         => $route,
 			'strategy'      => $strategy,
 			'strategy_args' => $args,
+			'method'        => $method,
 		);
 	}
 


### PR DESCRIPTION
Fixes #213.

By adding a `method` argument when calling `\WP_Service_Worker_Caching_Routes::register()`:

```php
add_action( 'wp_front_service_worker', function( \WP_Service_Worker_Scripts $scripts ) {
	$scripts->caching_routes()->register(
		'/api/.*\.json',
		[
			'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST,
			'cacheName' => 'my-api',
			'plugins'   => [
				'expiration' => [
					'maxAgeSeconds' => 60 * 60 * 24,
				],
			],
			'method'   => 'POST', // 👈 👈 👈
		]
	);
} );
```

The service worker is generated with that method passed as the third argument for [`workbox.routing.registerRoute()`](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing#.registerRoute): 

```js
wp.serviceWorker.routing.registerRoute( new RegExp( "/api/.*\\.json" ), new wp.serviceWorker.strategies[ "NetworkFirst" ]( ( function () {
    const strategyArgs = {
        "cacheName": "my-api"
    };
    if ( strategyArgs.cacheName && wp.serviceWorker.core.cacheNames.prefix ) {
        strategyArgs.cacheName = `${wp.serviceWorker.core.cacheNames.prefix}-${strategyArgs.cacheName}`;
    }
    strategyArgs.plugins = [ new wp.serviceWorker[ "expiration" ].Plugin( {
        "maxAgeSeconds": 86400
    } ) ];
    return strategyArgs;
} )() ), "POST" );

```