### PR TITLE
Temporarily restore STREAM_THEME_SUPPORT constant to fix fatal error when referenced

### DIFF
--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -14,6 +14,16 @@
 class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worker_Component {
 
 	/**
+	 * Slug used to identify whether a theme supports service worker streaming.
+	 *
+	 * @since 0.2
+	 * @since 0.4 Obsolete.
+	 * @var string
+	 * @deprecated Since 0.4 all streaming support was removed. See <https://github.com/xwp/pwa-wp/issues/191>. Constant is left in place for the time to prevent fatal error if referenced.
+	 */
+	const STREAM_THEME_SUPPORT = 'service_worker_streaming';
+
+	/**
 	 * Internal storage for replacements to make in the error response handling script.
 	 *
 	 * @since 0.2


### PR DESCRIPTION
This fixes a fatal error introduced in #215 when a plugin refers to the `STREAM_THEME_SUPPORT` constant:

> PHP Fatal error:  Uncaught Error: Undefined class constant 'STREAM_THEME_SUPPORT' in /app/public/content/plugins/amp/includes/class-amp-theme-support.php:1853

The only known plugin that references this constant is the AMP plugin, which is removing stream support in https://github.com/ampproject/amp-wp/pull/3059.