### PR TITLE
Prefix Workbox 'Plugin' classes with the module name after renamed in v5

### DIFF
--- a/wp-includes/components/class-wp-service-worker-caching-routes.php
+++ b/wp-includes/components/class-wp-service-worker-caching-routes.php
@@ -189,8 +189,9 @@ class WP_Service_Worker_Caching_Routes implements WP_Service_Worker_Registry {
 					_doing_it_wrong( 'WP_Service_Workers::register_cached_route', esc_html( sprintf( __( 'Unrecognized plugin: %s', 'pwa' ), $plugin_name ) ), '0.2' );
 				} else {
 					$plugins_js[] = sprintf(
-						'new wp.serviceWorker[ %s ].Plugin( %s )',
+						'new wp.serviceWorker[ %s ][ %s ]( %s )',
 						wp_service_worker_json_encode( $plugin_name ),
+						wp_service_worker_json_encode( ucfirst( $plugin_name ) . 'Plugin' ),
 						empty( $plugin_args ) ? '{}' : wp_service_worker_json_encode( $plugin_args )
 					);
 				}


### PR DESCRIPTION
I noticed an error after upgrading to Workbox v5.0.0-beta.0 (#218):

<img width="539" alt="Screen Shot 2019-08-22 at 17 16 14" src="https://user-images.githubusercontent.com/134745/63558256-0e799900-c501-11e9-97e0-916386688a7f.png">

The issue is that `{x}.Plugin` was renamed to `{x}.{X}Plugin` in https://github.com/GoogleChrome/workbox/issues/2072.

So this PR changes the generated JS as follows:

```diff
- new wp.serviceWorker[ "expiration" ].Plugin( { /* ... */ } )
+ new wp.serviceWorker[ "expiration" ][ "ExpirationPlugin" ]( { /* ... */ } )
```