### PR TITLE
Add offline templates for bundled core themes

### DIFF
--- a/bundled-theme-support/twentyeleven/offline.php
+++ b/bundled-theme-support/twentyeleven/offline.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Eleven
+ */
+
+// Prevent showing nav menus.
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+// Prevent showing search form.
+add_filter( 'get_search_form', '__return_empty_string' );
+
+get_header(); ?>
+
+<div id="primary">
+	<div id="content" role="main">
+
+		<article id="post-0">
+			<header class="entry-header">
+				<h1 class="entry-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+			</header>
+
+			<div class="entry-content">
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+
+			</div><!-- .entry-content -->
+		</article><!-- #post-0 -->
+
+	</div><!-- #content -->
+</div><!-- #primary -->
+
+<?php get_footer(); ?>

--- a/bundled-theme-support/twentyfifteen/offline.php
+++ b/bundled-theme-support/twentyfifteen/offline.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Fifteen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'has_nav_menu', '__return_false' );
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+add_action(
+	'wp_enqueue_scripts',
+	function () {
+		wp_add_inline_style( 'twentyfifteen-style', '.secondary-toggle { display: none; }' );
+	},
+	20
+);
+
+// Prevent showing widgets.
+add_filter( 'sidebars_widgets', '__return_empty_array' );
+
+get_header(); ?>
+
+<div id="primary" class="content-area">
+	<main id="main" class="site-main" role="main">
+
+		<section class="error-404 not-found">
+			<header class="page-header">
+				<h1 class="page-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+			</header><!-- .page-header -->
+
+			<div class="page-content">
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+			</div><!-- .page-content -->
+		</section><!-- .error-404 -->
+
+	</main><!-- .site-main -->
+</div><!-- .content-area -->
+
+<?php get_footer(); ?>

--- a/bundled-theme-support/twentyfourteen/offline.php
+++ b/bundled-theme-support/twentyfourteen/offline.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Fourteen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+// Prevent showing search form.
+add_filter( 'get_search_form', '__return_empty_string' );
+add_action(
+	'wp_enqueue_scripts',
+	function () {
+		wp_add_inline_style( 'twentyfourteen-style', '.search-toggle { display: none; }' );
+	},
+	20
+);
+
+get_header(); ?>
+
+	<div id="primary" class="content-area">
+		<div id="content" class="site-content" role="main">
+
+			<header class="page-header">
+				<h1 class="page-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+			</header>
+
+			<div class="page-content">
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+			</div><!-- .page-content -->
+
+		</div><!-- #content -->
+	</div><!-- #primary -->
+
+<?php
+get_footer();

--- a/bundled-theme-support/twentynineteen/offline.php
+++ b/bundled-theme-support/twentynineteen/offline.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Nineteen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+// Add the body class for the 404 template for the sake of styling.
+add_filter(
+	'body_class',
+	function( $body_classes ) {
+		$body_classes[] = 'error404';
+		return $body_classes;
+	}
+);
+
+// Prevent showing widgets.
+add_filter( 'sidebars_widgets', '__return_empty_array' );
+
+get_header();
+?>
+
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main">
+
+			<div class="error-404 not-found">
+				<header class="page-header">
+					<h1 class="page-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+				</header><!-- .page-header -->
+
+				<div class="page-content">
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+				</div><!-- .page-content -->
+			</div><!-- .error-404 -->
+
+		</main><!-- #main -->
+	</div><!-- #primary -->
+
+<?php
+get_footer();

--- a/bundled-theme-support/twentyseventeen/offline.php
+++ b/bundled-theme-support/twentyseventeen/offline.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Seventeen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'has_nav_menu', '__return_false' );
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+get_header(); ?>
+
+<div class="wrap">
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+			<section class="error-offline">
+				<header class="page-header">
+					<h1 class="page-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+				</header><!-- .page-header -->
+
+				<div class="page-content">
+					<?php
+					if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+						wp_service_worker_error_message_placeholder();
+					}
+					?>
+				</div><!-- .page-content -->
+			</section><!-- .error-offline -->
+		</main><!-- #main -->
+	</div><!-- #primary -->
+</div><!-- .wrap -->
+
+<?php
+get_footer();

--- a/bundled-theme-support/twentysixteen/offline.php
+++ b/bundled-theme-support/twentysixteen/offline.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Sixteen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'has_nav_menu', '__return_false' );
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+// Add the body class for the 404 template for the sake of styling.
+add_filter(
+	'body_class',
+	function( $body_classes ) {
+		$body_classes[] = 'error404';
+		return $body_classes;
+	}
+);
+
+get_header(); ?>
+
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+			<section class="error-404 not-found">
+				<header class="page-header">
+					<h1 class="page-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+				</header><!-- .page-header -->
+
+				<div class="page-content">
+					<?php
+					if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+						wp_service_worker_error_message_placeholder();
+					}
+					?>
+				</div><!-- .page-content -->
+			</section><!-- .error-404 -->
+
+		</main><!-- .site-main -->
+
+	</div><!-- .content-area -->
+
+<?php get_footer(); ?>

--- a/bundled-theme-support/twentyten/offline.php
+++ b/bundled-theme-support/twentyten/offline.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Ten
+ */
+
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+get_header(); ?>
+
+<div id="container">
+	<div id="content" role="main">
+
+		<div id="post-0" class="post error404 not-found">
+			<h1 class="entry-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+			<div class="entry-content">
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+			</div><!-- .entry-content -->
+		</div><!-- #post-0 -->
+
+	</div><!-- #content -->
+</div><!-- #container -->
+
+<?php get_footer(); ?>

--- a/bundled-theme-support/twentythirteen/offline.php
+++ b/bundled-theme-support/twentythirteen/offline.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Fifteen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+add_filter( 'has_nav_menu', '__return_false' );
+
+// Prevent showing search form.
+add_filter( 'get_search_form', '__return_empty_string' );
+
+// Prevent showing widgets.
+add_filter( 'sidebars_widgets', '__return_empty_array' );
+
+add_action(
+	'wp_enqueue_scripts',
+	function () {
+		wp_add_inline_style( 'twentythirteen-style', '#site-navigation { display: none; } .page-content { padding: 20px; }' );
+	},
+	20
+);
+
+get_header(); ?>
+
+<div id="primary" class="content-area">
+	<main id="main" class="site-main" role="main">
+
+		<div class="page-wrapper">
+			<div class="page-content">
+				<h1 class="offline-page-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+			</div><!-- .page-content -->
+		</div><!-- .page-wrapper -->
+
+	</main><!-- .site-main -->
+</div><!-- .content-area -->
+
+<?php get_footer(); ?>

--- a/bundled-theme-support/twentytwelve/offline.php
+++ b/bundled-theme-support/twentytwelve/offline.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twelve
+ */
+
+// Prevent showing nav menus.
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+
+get_header(); ?>
+
+<div id="primary" class="site-content">
+	<div id="content" role="main">
+
+		<article id="post-0">
+			<header class="entry-header">
+				<h1 class="entry-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+			</header>
+
+			<div class="entry-content">
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+			</div><!-- .entry-content -->
+		</article><!-- #post-0 -->
+
+	</div><!-- #content -->
+</div><!-- #primary -->
+
+<?php get_footer(); ?>

--- a/bundled-theme-support/twentytwenty/offline.php
+++ b/bundled-theme-support/twentytwenty/offline.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @package WordPress
+ * @subpackage Twenty_Thirteen
+ */
+
+// Prevent showing nav menus.
+add_filter( 'pre_wp_nav_menu', '__return_empty_string' );
+add_action(
+	'wp_enqueue_scripts',
+	function () {
+		wp_add_inline_style( 'twentytwenty-style', '.header-toggles, .header-inner .mobile-search-toggle, .header-inner .nav-toggle, .to-the-top { display: none; }' );
+	},
+	20
+);
+
+// Prevent showing search form.
+add_filter( 'get_search_form', '__return_empty_string' );
+
+// Add the body class for the 404 template for the sake of styling.
+add_filter(
+	'body_class',
+	function( $body_classes ) {
+		$body_classes[] = 'error404';
+		return $body_classes;
+	}
+);
+
+get_header();
+?>
+
+<main id="site-content" role="main">
+
+	<div class="section-inner thin error404-content">
+
+		<h1 class="entry-title"><?php esc_html_e( 'Offline', 'pwa' ); ?></h1>
+
+		<div class="intro-text">
+			<?php
+			if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+				wp_service_worker_error_message_placeholder();
+			}
+			?>
+		</div>
+
+	</div><!-- .section-inner -->
+
+</main><!-- #site-content -->
+
+<?php
+get_footer();

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -34,12 +34,17 @@ function pwa_locate_template( $template_names, $load = false, $require_once = tr
 		if ( ! $template_name ) {
 			continue;
 		}
+		$theme_slug = get_template();
 		if ( file_exists( STYLESHEETPATH . '/' . $template_name ) ) {
 			$located = STYLESHEETPATH . '/' . $template_name;
 			break;
 		} elseif ( file_exists( TEMPLATEPATH . '/' . $template_name ) ) {
 			$located = TEMPLATEPATH . '/' . $template_name;
 			break;
+		} elseif ( preg_match( '/^twenty\w+$/', $theme_slug ) && file_exists( PWA_PLUGIN_DIR . '/bundled-theme-support/' . $theme_slug . '/offline.php' ) ) {
+			$located = PWA_PLUGIN_DIR . '/bundled-theme-support/' . $theme_slug . '/offline.php';
+			break;
+			// Begin core patch.
 		} elseif ( file_exists( PWA_PLUGIN_DIR . '/' . WPINC . '/theme-compat/' . $template_name ) ) {
 			$located = PWA_PLUGIN_DIR . '/' . WPINC . '/theme-compat/' . $template_name;
 			break;


### PR DESCRIPTION
Fixes #199.

In the following screenshots, the site title is “WordPress Develop”.

For each core bundled theme, the `offline.php` template is based off of the `404.php` template (except for Twenty Thirteen). In each case:

* The nav menu is hidden.
* The search box is hidden.
* The widgets are hidden.

# Twenty Twenty

![twentytwenty](https://user-images.githubusercontent.com/134745/68091116-6ad23080-fe41-11e9-9232-bca9b5336e84.png)

# Twenty Nineteen

![twentynineteen](https://user-images.githubusercontent.com/134745/68091117-6efe4e00-fe41-11e9-8a91-81d62cffd5d1.png)

# Twenty Seventeen

![twentyseventeen](https://user-images.githubusercontent.com/134745/68091118-732a6b80-fe41-11e9-841e-5f293a35c8fb.png)

# Twenty Sixteen

![twentysixteen](https://user-images.githubusercontent.com/134745/68091120-79204c80-fe41-11e9-8600-0d34e3b91d30.png)

# Twenty Fifteen

![twentyfifteen](https://user-images.githubusercontent.com/134745/68091124-7f162d80-fe41-11e9-80bd-5db5f9b5384b.png)

# Twenty Fourteen

![twentyfourteen](https://user-images.githubusercontent.com/134745/68091129-85a4a500-fe41-11e9-9c2a-7317c0da16a8.png)

# Twenty Thirteen

![twentythirteen](https://user-images.githubusercontent.com/134745/68091131-8c331c80-fe41-11e9-9ca5-ef29e04cc67e.png)

# Twenty Twelve

![twentytwelve](https://user-images.githubusercontent.com/134745/68091132-91906700-fe41-11e9-8767-dd560430aa05.png)

# Twenty Eleven

![twentyeleven](https://user-images.githubusercontent.com/134745/68091133-95bc8480-fe41-11e9-8bf4-4f2ae81afa12.png)

# Twenty Ten

Note that this theme is not responsive for mobile.

![twentyten](https://user-images.githubusercontent.com/134745/68091143-a836be00-fe41-11e9-8168-e8385ae701da.png)
