### PR TITLE
Prevent including HTML entities in web app manifest name and description fields

### DIFF
--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -130,12 +130,12 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 	 */
 	public function test_get_manifest() {
 		$this->mock_site_icon();
-		$blogname = 'PWA & Test "First" and \'second\'';
+		$blogname = 'PWA & Test "First" and \'second\' and “third”';
 		update_option( 'blogname', $blogname );
 		$actual_manifest = $this->instance->get_manifest();
 
 		// Verify that there are now entities.
-		$this->assertEquals( 'PWA &amp; Test &quot;First&quot; and &#039;second&#039;', get_option( 'blogname' ) );
+		$this->assertEquals( 'PWA &amp; Test &quot;First&quot; and &#039;second&#039; and “third”', get_option( 'blogname' ) );
 
 		$expected_manifest = array(
 			'background_color' => WP_Web_App_Manifest::FALLBACK_THEME_COLOR,

--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -130,16 +130,18 @@ class Test_WP_Web_App_Manifest extends WP_UnitTestCase {
 	 */
 	public function test_get_manifest() {
 		$this->mock_site_icon();
-		$blogname = 'PWA Test';
+		$blogname = 'PWA & Test "First" and \'second\'';
 		update_option( 'blogname', $blogname );
 		$actual_manifest = $this->instance->get_manifest();
+
+		// Verify that there are now entities.
+		$this->assertEquals( 'PWA &amp; Test &quot;First&quot; and &#039;second&#039;', get_option( 'blogname' ) );
 
 		$expected_manifest = array(
 			'background_color' => WP_Web_App_Manifest::FALLBACK_THEME_COLOR,
 			'description'      => get_bloginfo( 'description' ),
 			'display'          => 'minimal-ui',
-			'name'             => $blogname,
-			'short_name'       => $blogname,
+			'name'             => $blogname, // No HTML entities should be in the manifest.
 			'lang'             => get_bloginfo( 'language' ),
 			'dir'              => is_rtl() ? 'rtl' : 'ltr',
 			'start_url'        => home_url( '/' ),

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -129,7 +129,7 @@ class WP_Web_App_Manifest {
 	 */
 	public function get_manifest() {
 		$manifest = array(
-			'name'      => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, '' ),
+			'name'      => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, 'utf-8' ),
 			'start_url' => home_url( '/' ),
 			'display'   => 'minimal-ui',
 			'dir'       => is_rtl() ? 'rtl' : 'ltr',
@@ -158,7 +158,7 @@ class WP_Web_App_Manifest {
 			$manifest['theme_color']      = $theme_color;
 		}
 
-		$description = html_entity_decode( get_bloginfo( 'description' ), ENT_QUOTES, '' );
+		$description = html_entity_decode( get_bloginfo( 'description' ), ENT_QUOTES, 'utf-8' );
 		if ( $description ) {
 			$manifest['description'] = $description;
 		}

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -129,7 +129,7 @@ class WP_Web_App_Manifest {
 	 */
 	public function get_manifest() {
 		$manifest = array(
-			'name'      => wp_kses_decode_entities( get_bloginfo( 'name' ) ),
+			'name'      => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, '' ),
 			'start_url' => home_url( '/' ),
 			'display'   => 'minimal-ui',
 			'dir'       => is_rtl() ? 'rtl' : 'ltr',
@@ -158,7 +158,7 @@ class WP_Web_App_Manifest {
 			$manifest['theme_color']      = $theme_color;
 		}
 
-		$description = wp_kses_decode_entities( get_bloginfo( 'description' ) );
+		$description = html_entity_decode( get_bloginfo( 'description' ), ENT_QUOTES, '' );
 		if ( $description ) {
 			$manifest['description'] = $description;
 		}


### PR DESCRIPTION
I tried setting the blogname to:

```
WordPress & "Develop" and 'food' and “drink” 😀
```

And the manifest then erroneously included:

```json
{"name":"WordPress &amp; &quot;Develop&quot; and 'food' and \u201cdrink\u201d \ud83d\ude00")
```

There are named entities which need to be decoded, which `wp_kses_decode_entities()` doesn't do. So we need to use `html_entity_decode()` instead.

After the changes here, the manifest then includes:

```json
{"name":"WordPress & \"Develop\" and 'food' and \u201cdrink\u201d \ud83d\ude00"}
```