### PR TITLE
Update workbox to v5.0.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,21 +12,33 @@
     "@babel/highlight": "^7.0.0"
    }
   },
-  "@babel/core": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
-   "integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
+  "@babel/compat-data": {
+   "version": "7.8.1",
+   "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
+   "integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
    "dev": true,
    "requires": {
-    "@babel/code-frame": "^7.5.5",
-    "@babel/generator": "^7.7.4",
-    "@babel/helpers": "^7.7.4",
-    "@babel/parser": "^7.7.4",
-    "@babel/template": "^7.7.4",
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4",
+    "browserslist": "^4.8.2",
+    "invariant": "^2.2.4",
+    "semver": "^5.5.0"
+   }
+  },
+  "@babel/core": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+   "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+   "dev": true,
+   "requires": {
+    "@babel/code-frame": "^7.8.3",
+    "@babel/generator": "^7.8.3",
+    "@babel/helpers": "^7.8.3",
+    "@babel/parser": "^7.8.3",
+    "@babel/template": "^7.8.3",
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
+    "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.0",
     "lodash": "^4.17.13",
     "resolve": "^1.3.2",
@@ -35,93 +47,104 @@
    },
    "dependencies": {
     "@babel/code-frame": {
-     "version": "7.5.5",
-     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-     "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/highlight": "^7.0.0"
+      "@babel/highlight": "^7.8.3"
      }
     },
     "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -130,9 +153,9 @@
      }
     },
     "resolve": {
-     "version": "1.13.1",
-     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-     "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+     "version": "1.15.0",
+     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+     "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
      "dev": true,
      "requires": {
       "path-parse": "^1.0.6"
@@ -154,18 +177,18 @@
    }
   },
   "@babel/helper-annotate-as-pure": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
-   "integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+   "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.7.4"
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -176,19 +199,19 @@
    }
   },
   "@babel/helper-builder-binary-assignment-operator-visitor": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
-   "integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+   "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
    "dev": true,
    "requires": {
-    "@babel/helper-explode-assignable-expression": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/helper-explode-assignable-expression": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -199,104 +222,115 @@
    }
   },
   "@babel/helper-call-delegate": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
-   "integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.3.tgz",
+   "integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
    "dev": true,
    "requires": {
-    "@babel/helper-hoist-variables": "^7.7.4",
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/helper-hoist-variables": "^7.8.3",
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/code-frame": {
-     "version": "7.5.5",
-     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-     "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/highlight": "^7.0.0"
+      "@babel/highlight": "^7.8.3"
      }
     },
     "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -306,68 +340,101 @@
     }
    }
   },
-  "@babel/helper-create-regexp-features-plugin": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
-   "integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+  "@babel/helper-compilation-targets": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
+   "integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
    "dev": true,
    "requires": {
-    "@babel/helper-regex": "^7.4.4",
+    "@babel/compat-data": "^7.8.1",
+    "browserslist": "^4.8.2",
+    "invariant": "^2.2.4",
+    "levenary": "^1.1.0",
+    "semver": "^5.5.0"
+   }
+  },
+  "@babel/helper-create-regexp-features-plugin": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
+   "integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-regex": "^7.8.3",
     "regexpu-core": "^4.6.0"
    }
   },
   "@babel/helper-define-map": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
-   "integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+   "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
    "dev": true,
    "requires": {
-    "@babel/helper-function-name": "^7.7.4",
-    "@babel/types": "^7.7.4",
+    "@babel/helper-function-name": "^7.8.3",
+    "@babel/types": "^7.8.3",
     "lodash": "^4.17.13"
    },
    "dependencies": {
-    "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/helper-function-name": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -378,103 +445,114 @@
    }
   },
   "@babel/helper-explode-assignable-expression": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
-   "integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+   "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
    "dev": true,
    "requires": {
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/code-frame": {
-     "version": "7.5.5",
-     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-     "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/highlight": "^7.0.0"
+      "@babel/highlight": "^7.8.3"
      }
     },
     "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -505,18 +583,18 @@
    }
   },
   "@babel/helper-hoist-variables": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
-   "integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+   "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.7.4"
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -527,18 +605,18 @@
    }
   },
   "@babel/helper-member-expression-to-functions": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
-   "integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+   "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.7.4"
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -549,18 +627,18 @@
    }
   },
   "@babel/helper-module-imports": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-   "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+   "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.7.4"
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -571,49 +649,69 @@
    }
   },
   "@babel/helper-module-transforms": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz",
-   "integrity": "sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
+   "integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-imports": "^7.7.4",
-    "@babel/helper-simple-access": "^7.7.4",
-    "@babel/helper-split-export-declaration": "^7.7.4",
-    "@babel/template": "^7.7.4",
-    "@babel/types": "^7.7.4",
+    "@babel/helper-module-imports": "^7.8.3",
+    "@babel/helper-simple-access": "^7.8.3",
+    "@babel/helper-split-export-declaration": "^7.8.3",
+    "@babel/template": "^7.8.3",
+    "@babel/types": "^7.8.3",
     "lodash": "^4.17.13"
    },
    "dependencies": {
-    "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/helper-split-export-declaration": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -624,18 +722,18 @@
    }
   },
   "@babel/helper-optimise-call-expression": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
-   "integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+   "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.7.4"
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -646,123 +744,132 @@
    }
   },
   "@babel/helper-plugin-utils": {
-   "version": "7.0.0",
-   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-   "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+   "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
    "dev": true
   },
   "@babel/helper-regex": {
-   "version": "7.5.5",
-   "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-   "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+   "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
    "dev": true,
    "requires": {
     "lodash": "^4.17.13"
    }
   },
   "@babel/helper-remap-async-to-generator": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
-   "integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+   "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
    "dev": true,
    "requires": {
-    "@babel/helper-annotate-as-pure": "^7.7.4",
-    "@babel/helper-wrap-function": "^7.7.4",
-    "@babel/template": "^7.7.4",
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/helper-annotate-as-pure": "^7.8.3",
+    "@babel/helper-wrap-function": "^7.8.3",
+    "@babel/template": "^7.8.3",
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
-    "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/generator": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
-     },
-     "dependencies": {
-      "@babel/code-frame": {
-       "version": "7.5.5",
-       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-       "dev": true,
-       "requires": {
-        "@babel/highlight": "^7.0.0"
-       }
-      }
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -773,105 +880,116 @@
    }
   },
   "@babel/helper-replace-supers": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
-   "integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
+   "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
    "dev": true,
    "requires": {
-    "@babel/helper-member-expression-to-functions": "^7.7.4",
-    "@babel/helper-optimise-call-expression": "^7.7.4",
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/helper-member-expression-to-functions": "^7.8.3",
+    "@babel/helper-optimise-call-expression": "^7.8.3",
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
     "@babel/code-frame": {
-     "version": "7.5.5",
-     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-     "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/highlight": "^7.0.0"
+      "@babel/highlight": "^7.8.3"
      }
     },
     "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -882,36 +1000,56 @@
    }
   },
   "@babel/helper-simple-access": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
-   "integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+   "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
    "dev": true,
    "requires": {
-    "@babel/template": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/template": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
+     }
+    },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -931,107 +1069,116 @@
    }
   },
   "@babel/helper-wrap-function": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
-   "integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+   "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-function-name": "^7.7.4",
-    "@babel/template": "^7.7.4",
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/helper-function-name": "^7.8.3",
+    "@babel/template": "^7.8.3",
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
-    "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/generator": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
-     },
-     "dependencies": {
-      "@babel/code-frame": {
-       "version": "7.5.5",
-       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-       "dev": true,
-       "requires": {
-        "@babel/highlight": "^7.0.0"
-       }
-      }
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -1042,106 +1189,115 @@
    }
   },
   "@babel/helpers": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-   "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
+   "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
    "dev": true,
    "requires": {
-    "@babel/template": "^7.7.4",
-    "@babel/traverse": "^7.7.4",
-    "@babel/types": "^7.7.4"
+    "@babel/template": "^7.8.3",
+    "@babel/traverse": "^7.8.3",
+    "@babel/types": "^7.8.3"
    },
    "dependencies": {
-    "@babel/generator": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-     "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4",
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/generator": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+     "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.8.3",
       "jsesc": "^2.5.1",
       "lodash": "^4.17.13",
       "source-map": "^0.5.0"
      }
     },
     "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/traverse": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-     "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+     "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.5.5",
-      "@babel/generator": "^7.7.4",
-      "@babel/helper-function-name": "^7.7.4",
-      "@babel/helper-split-export-declaration": "^7.7.4",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4",
+      "@babel/code-frame": "^7.8.3",
+      "@babel/generator": "^7.8.3",
+      "@babel/helper-function-name": "^7.8.3",
+      "@babel/helper-split-export-declaration": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3",
       "debug": "^4.1.0",
       "globals": "^11.1.0",
       "lodash": "^4.17.13"
-     },
-     "dependencies": {
-      "@babel/code-frame": {
-       "version": "7.5.5",
-       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-       "dev": true,
-       "requires": {
-        "@babel/highlight": "^7.0.0"
-       }
-      }
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -1169,225 +1325,283 @@
    "dev": true
   },
   "@babel/plugin-proposal-async-generator-functions": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
-   "integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+   "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-remap-async-to-generator": "^7.7.4",
-    "@babel/plugin-syntax-async-generators": "^7.7.4"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/helper-remap-async-to-generator": "^7.8.3",
+    "@babel/plugin-syntax-async-generators": "^7.8.0"
    }
   },
   "@babel/plugin-proposal-dynamic-import": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
-   "integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+   "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-syntax-dynamic-import": "^7.7.4"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.0"
    }
   },
   "@babel/plugin-proposal-json-strings": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
-   "integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+   "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-syntax-json-strings": "^7.7.4"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-syntax-json-strings": "^7.8.0"
+   }
+  },
+  "@babel/plugin-proposal-nullish-coalescing-operator": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+   "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
    }
   },
   "@babel/plugin-proposal-object-rest-spread": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
-   "integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+   "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
    }
   },
   "@babel/plugin-proposal-optional-catch-binding": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
-   "integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+   "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+   }
+  },
+  "@babel/plugin-proposal-optional-chaining": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+   "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-syntax-optional-chaining": "^7.8.0"
    }
   },
   "@babel/plugin-proposal-unicode-property-regex": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
-   "integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+   "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-syntax-async-generators": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
-   "integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+   "version": "7.8.4",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+   "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.0"
    }
   },
   "@babel/plugin-syntax-dynamic-import": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
-   "integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+   "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.0"
    }
   },
   "@babel/plugin-syntax-json-strings": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
-   "integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+   "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.0"
+   }
+  },
+  "@babel/plugin-syntax-nullish-coalescing-operator": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+   "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-plugin-utils": "^7.8.0"
    }
   },
   "@babel/plugin-syntax-object-rest-spread": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
-   "integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+   "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.0"
    }
   },
   "@babel/plugin-syntax-optional-catch-binding": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
-   "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+   "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.0"
+   }
+  },
+  "@babel/plugin-syntax-optional-chaining": {
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+   "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+   "dev": true,
+   "requires": {
+    "@babel/helper-plugin-utils": "^7.8.0"
    }
   },
   "@babel/plugin-syntax-top-level-await": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
-   "integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+   "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-arrow-functions": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
-   "integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+   "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-async-to-generator": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
-   "integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+   "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-imports": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-remap-async-to-generator": "^7.7.4"
+    "@babel/helper-module-imports": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/helper-remap-async-to-generator": "^7.8.3"
    }
   },
   "@babel/plugin-transform-block-scoped-functions": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
-   "integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+   "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-block-scoping": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
-   "integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+   "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
+    "@babel/helper-plugin-utils": "^7.8.3",
     "lodash": "^4.17.13"
    }
   },
   "@babel/plugin-transform-classes": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
-   "integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
+   "integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
    "dev": true,
    "requires": {
-    "@babel/helper-annotate-as-pure": "^7.7.4",
-    "@babel/helper-define-map": "^7.7.4",
-    "@babel/helper-function-name": "^7.7.4",
-    "@babel/helper-optimise-call-expression": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-replace-supers": "^7.7.4",
-    "@babel/helper-split-export-declaration": "^7.7.4",
+    "@babel/helper-annotate-as-pure": "^7.8.3",
+    "@babel/helper-define-map": "^7.8.3",
+    "@babel/helper-function-name": "^7.8.3",
+    "@babel/helper-optimise-call-expression": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/helper-replace-supers": "^7.8.3",
+    "@babel/helper-split-export-declaration": "^7.8.3",
     "globals": "^11.1.0"
    },
    "dependencies": {
-    "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/helper-function-name": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-split-export-declaration": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-     "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+     "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -1398,112 +1612,132 @@
    }
   },
   "@babel/plugin-transform-computed-properties": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
-   "integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+   "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-destructuring": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
-   "integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+   "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-dotall-regex": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
-   "integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+   "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
    "dev": true,
    "requires": {
-    "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-duplicate-keys": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
-   "integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+   "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-exponentiation-operator": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
-   "integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+   "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-for-of": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
-   "integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz",
+   "integrity": "sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-function-name": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
-   "integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+   "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-function-name": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-function-name": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    },
    "dependencies": {
-    "@babel/helper-function-name": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-     "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
      "dev": true,
      "requires": {
-      "@babel/helper-get-function-arity": "^7.7.4",
-      "@babel/template": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/helper-function-name": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+     "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-get-function-arity": "^7.8.3",
+      "@babel/template": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
      }
     },
     "@babel/parser": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-     "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+     "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
      "dev": true
     },
     "@babel/template": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-     "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+     "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
      "dev": true,
      "requires": {
-      "@babel/code-frame": "^7.0.0",
-      "@babel/parser": "^7.7.4",
-      "@babel/types": "^7.7.4"
+      "@babel/code-frame": "^7.8.3",
+      "@babel/parser": "^7.8.3",
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -1514,119 +1748,120 @@
    }
   },
   "@babel/plugin-transform-literals": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
-   "integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+   "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-member-expression-literals": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
-   "integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+   "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-modules-amd": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.4.tgz",
-   "integrity": "sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+   "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-transforms": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0",
+    "@babel/helper-module-transforms": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3",
     "babel-plugin-dynamic-import-node": "^2.3.0"
    }
   },
   "@babel/plugin-transform-modules-commonjs": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz",
-   "integrity": "sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+   "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-transforms": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-simple-access": "^7.7.4",
+    "@babel/helper-module-transforms": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/helper-simple-access": "^7.8.3",
     "babel-plugin-dynamic-import-node": "^2.3.0"
    }
   },
   "@babel/plugin-transform-modules-systemjs": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
-   "integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+   "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
    "dev": true,
    "requires": {
-    "@babel/helper-hoist-variables": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0",
+    "@babel/helper-hoist-variables": "^7.8.3",
+    "@babel/helper-module-transforms": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3",
     "babel-plugin-dynamic-import-node": "^2.3.0"
    }
   },
   "@babel/plugin-transform-modules-umd": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
-   "integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+   "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-transforms": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-module-transforms": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-named-capturing-groups-regex": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
-   "integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+   "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
    "dev": true,
    "requires": {
-    "@babel/helper-create-regexp-features-plugin": "^7.7.4"
+    "@babel/helper-create-regexp-features-plugin": "^7.8.3"
    }
   },
   "@babel/plugin-transform-new-target": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
-   "integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+   "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-object-super": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
-   "integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+   "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-replace-supers": "^7.7.4"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/helper-replace-supers": "^7.8.3"
    }
   },
   "@babel/plugin-transform-parameters": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
-   "integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz",
+   "integrity": "sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==",
    "dev": true,
    "requires": {
-    "@babel/helper-call-delegate": "^7.7.4",
-    "@babel/helper-get-function-arity": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-call-delegate": "^7.8.3",
+    "@babel/helper-get-function-arity": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    },
    "dependencies": {
     "@babel/helper-get-function-arity": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-     "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+     "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
      "dev": true,
      "requires": {
-      "@babel/types": "^7.7.4"
+      "@babel/types": "^7.8.3"
      }
     },
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -1637,152 +1872,158 @@
    }
   },
   "@babel/plugin-transform-property-literals": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
-   "integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+   "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-regenerator": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.4.tgz",
-   "integrity": "sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.3.tgz",
+   "integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
    "dev": true,
    "requires": {
     "regenerator-transform": "^0.14.0"
    }
   },
   "@babel/plugin-transform-reserved-words": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
-   "integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+   "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-shorthand-properties": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
-   "integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+   "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-spread": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
-   "integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+   "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-sticky-regex": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
-   "integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+   "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/helper-regex": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/helper-regex": "^7.8.3"
    }
   },
   "@babel/plugin-transform-template-literals": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
-   "integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+   "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
    "dev": true,
    "requires": {
-    "@babel/helper-annotate-as-pure": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-annotate-as-pure": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-typeof-symbol": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
-   "integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz",
+   "integrity": "sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==",
    "dev": true,
    "requires": {
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/plugin-transform-unicode-regex": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
-   "integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+   "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
    "dev": true,
    "requires": {
-    "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0"
+    "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3"
    }
   },
   "@babel/preset-env": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",
-   "integrity": "sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.3.tgz",
+   "integrity": "sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-imports": "^7.7.4",
-    "@babel/helper-plugin-utils": "^7.0.0",
-    "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
-    "@babel/plugin-proposal-dynamic-import": "^7.7.4",
-    "@babel/plugin-proposal-json-strings": "^7.7.4",
-    "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
-    "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-    "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
-    "@babel/plugin-syntax-async-generators": "^7.7.4",
-    "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-    "@babel/plugin-syntax-json-strings": "^7.7.4",
-    "@babel/plugin-syntax-object-rest-spread": "^7.7.4",
-    "@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
-    "@babel/plugin-syntax-top-level-await": "^7.7.4",
-    "@babel/plugin-transform-arrow-functions": "^7.7.4",
-    "@babel/plugin-transform-async-to-generator": "^7.7.4",
-    "@babel/plugin-transform-block-scoped-functions": "^7.7.4",
-    "@babel/plugin-transform-block-scoping": "^7.7.4",
-    "@babel/plugin-transform-classes": "^7.7.4",
-    "@babel/plugin-transform-computed-properties": "^7.7.4",
-    "@babel/plugin-transform-destructuring": "^7.7.4",
-    "@babel/plugin-transform-dotall-regex": "^7.7.4",
-    "@babel/plugin-transform-duplicate-keys": "^7.7.4",
-    "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
-    "@babel/plugin-transform-for-of": "^7.7.4",
-    "@babel/plugin-transform-function-name": "^7.7.4",
-    "@babel/plugin-transform-literals": "^7.7.4",
-    "@babel/plugin-transform-member-expression-literals": "^7.7.4",
-    "@babel/plugin-transform-modules-amd": "^7.7.4",
-    "@babel/plugin-transform-modules-commonjs": "^7.7.4",
-    "@babel/plugin-transform-modules-systemjs": "^7.7.4",
-    "@babel/plugin-transform-modules-umd": "^7.7.4",
-    "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
-    "@babel/plugin-transform-new-target": "^7.7.4",
-    "@babel/plugin-transform-object-super": "^7.7.4",
-    "@babel/plugin-transform-parameters": "^7.7.4",
-    "@babel/plugin-transform-property-literals": "^7.7.4",
-    "@babel/plugin-transform-regenerator": "^7.7.4",
-    "@babel/plugin-transform-reserved-words": "^7.7.4",
-    "@babel/plugin-transform-shorthand-properties": "^7.7.4",
-    "@babel/plugin-transform-spread": "^7.7.4",
-    "@babel/plugin-transform-sticky-regex": "^7.7.4",
-    "@babel/plugin-transform-template-literals": "^7.7.4",
-    "@babel/plugin-transform-typeof-symbol": "^7.7.4",
-    "@babel/plugin-transform-unicode-regex": "^7.7.4",
-    "@babel/types": "^7.7.4",
-    "browserslist": "^4.6.0",
-    "core-js-compat": "^3.1.1",
+    "@babel/compat-data": "^7.8.0",
+    "@babel/helper-compilation-targets": "^7.8.3",
+    "@babel/helper-module-imports": "^7.8.3",
+    "@babel/helper-plugin-utils": "^7.8.3",
+    "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+    "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+    "@babel/plugin-proposal-json-strings": "^7.8.3",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+    "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+    "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+    "@babel/plugin-syntax-async-generators": "^7.8.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+    "@babel/plugin-syntax-json-strings": "^7.8.0",
+    "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+    "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+    "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+    "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+    "@babel/plugin-syntax-top-level-await": "^7.8.3",
+    "@babel/plugin-transform-arrow-functions": "^7.8.3",
+    "@babel/plugin-transform-async-to-generator": "^7.8.3",
+    "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+    "@babel/plugin-transform-block-scoping": "^7.8.3",
+    "@babel/plugin-transform-classes": "^7.8.3",
+    "@babel/plugin-transform-computed-properties": "^7.8.3",
+    "@babel/plugin-transform-destructuring": "^7.8.3",
+    "@babel/plugin-transform-dotall-regex": "^7.8.3",
+    "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+    "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+    "@babel/plugin-transform-for-of": "^7.8.3",
+    "@babel/plugin-transform-function-name": "^7.8.3",
+    "@babel/plugin-transform-literals": "^7.8.3",
+    "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+    "@babel/plugin-transform-modules-amd": "^7.8.3",
+    "@babel/plugin-transform-modules-commonjs": "^7.8.3",
+    "@babel/plugin-transform-modules-systemjs": "^7.8.3",
+    "@babel/plugin-transform-modules-umd": "^7.8.3",
+    "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+    "@babel/plugin-transform-new-target": "^7.8.3",
+    "@babel/plugin-transform-object-super": "^7.8.3",
+    "@babel/plugin-transform-parameters": "^7.8.3",
+    "@babel/plugin-transform-property-literals": "^7.8.3",
+    "@babel/plugin-transform-regenerator": "^7.8.3",
+    "@babel/plugin-transform-reserved-words": "^7.8.3",
+    "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+    "@babel/plugin-transform-spread": "^7.8.3",
+    "@babel/plugin-transform-sticky-regex": "^7.8.3",
+    "@babel/plugin-transform-template-literals": "^7.8.3",
+    "@babel/plugin-transform-typeof-symbol": "^7.8.3",
+    "@babel/plugin-transform-unicode-regex": "^7.8.3",
+    "@babel/types": "^7.8.3",
+    "browserslist": "^4.8.2",
+    "core-js-compat": "^3.6.2",
     "invariant": "^2.2.2",
-    "js-levenshtein": "^1.1.3",
+    "levenary": "^1.1.0",
     "semver": "^5.5.0"
    },
    "dependencies": {
     "@babel/types": {
-     "version": "7.7.4",
-     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-     "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+     "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
      "dev": true,
      "requires": {
       "esutils": "^2.0.2",
@@ -1793,9 +2034,9 @@
    }
   },
   "@babel/runtime": {
-   "version": "7.7.4",
-   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-   "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+   "version": "7.8.3",
+   "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+   "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
    "dev": true,
    "requires": {
     "regenerator-runtime": "^0.13.2"
@@ -1905,15 +2146,15 @@
    }
   },
   "@types/estree": {
-   "version": "0.0.40",
-   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.40.tgz",
-   "integrity": "sha512-p3KZgMto/JyxosKGmnLDJ/dG5wf+qTRMUjHJcspC2oQKa4jP7mz+tv0ND56lLBu3ojHlhzY33Ol+khLyNmilkA==",
+   "version": "0.0.42",
+   "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
+   "integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==",
    "dev": true
   },
   "@types/node": {
-   "version": "12.12.14",
-   "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-   "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+   "version": "13.5.0",
+   "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
+   "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==",
    "dev": true
   },
   "@types/normalize-package-data": {
@@ -2207,6 +2448,15 @@
     }
    }
   },
+  "babel-extract-comments": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+   "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+   "dev": true,
+   "requires": {
+    "babylon": "^6.18.0"
+   }
+  },
   "babel-plugin-dynamic-import-node": {
    "version": "2.3.0",
    "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -2215,6 +2465,46 @@
    "requires": {
     "object.assign": "^4.1.0"
    }
+  },
+  "babel-plugin-syntax-object-rest-spread": {
+   "version": "6.13.0",
+   "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+   "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+   "dev": true
+  },
+  "babel-plugin-transform-object-rest-spread": {
+   "version": "6.26.0",
+   "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+   "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+   "dev": true,
+   "requires": {
+    "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+    "babel-runtime": "^6.26.0"
+   }
+  },
+  "babel-runtime": {
+   "version": "6.26.0",
+   "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+   "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+   "dev": true,
+   "requires": {
+    "core-js": "^2.4.0",
+    "regenerator-runtime": "^0.11.0"
+   },
+   "dependencies": {
+    "regenerator-runtime": {
+     "version": "0.11.1",
+     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+     "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+     "dev": true
+    }
+   }
+  },
+  "babylon": {
+   "version": "6.18.0",
+   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+   "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+   "dev": true
   },
   "balanced-match": {
    "version": "1.0.0",
@@ -2282,6 +2572,16 @@
    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
    "dev": true
+  },
+  "bindings": {
+   "version": "1.5.0",
+   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+   "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+   "dev": true,
+   "optional": true,
+   "requires": {
+    "file-uri-to-path": "1.0.0"
+   }
   },
   "boxen": {
    "version": "3.2.0",
@@ -2408,14 +2708,14 @@
    }
   },
   "browserslist": {
-   "version": "4.8.0",
-   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-   "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+   "version": "4.8.5",
+   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
+   "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
    "dev": true,
    "requires": {
-    "caniuse-lite": "^1.0.30001012",
-    "electron-to-chromium": "^1.3.317",
-    "node-releases": "^1.1.41"
+    "caniuse-lite": "^1.0.30001022",
+    "electron-to-chromium": "^1.3.338",
+    "node-releases": "^1.1.46"
    }
   },
   "buffer-from": {
@@ -2528,9 +2828,9 @@
    }
   },
   "caniuse-lite": {
-   "version": "1.0.30001012",
-   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001012.tgz",
-   "integrity": "sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg==",
+   "version": "1.0.30001023",
+   "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+   "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
    "dev": true
   },
   "chalk": {
@@ -2759,20 +3059,26 @@
    "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
    "dev": true
   },
+  "core-js": {
+   "version": "2.6.11",
+   "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+   "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+   "dev": true
+  },
   "core-js-compat": {
-   "version": "3.4.5",
-   "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.5.tgz",
-   "integrity": "sha512-rYVvzvKJDKoefdAC+q6VP63vp5hMmeVONCi9pVUbU1qRrtVrmAk/nPhnRg+i+XFd775m1hpG2Yd5RY3X45ccuw==",
+   "version": "3.6.4",
+   "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+   "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
    "dev": true,
    "requires": {
-    "browserslist": "^4.7.3",
-    "semver": "^6.3.0"
+    "browserslist": "^4.8.3",
+    "semver": "7.0.0"
    },
    "dependencies": {
     "semver": {
-     "version": "6.3.0",
-     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+     "version": "7.0.0",
+     "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+     "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
      "dev": true
     }
    }
@@ -2937,9 +3243,9 @@
    }
   },
   "defer-to-connect": {
-   "version": "1.1.0",
-   "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.0.tgz",
-   "integrity": "sha512-WE2sZoctWm/v4smfCAdjYbrfS55JiMRdlY9ZubFhsYbteCK9+BvAx4YV7nPjYM6ZnX5BcoVKwfmyx9sIFTgQMQ==",
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+   "integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==",
    "dev": true
   },
   "define-properties": {
@@ -3023,9 +3329,9 @@
    "dev": true
   },
   "electron-to-chromium": {
-   "version": "1.3.318",
-   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.318.tgz",
-   "integrity": "sha512-1RHv5OZGuVKvWYMVR6g1QVQVrsJRaujry04R/6t/7JVs68Ra4V8ewv63fiwcq0uiT302lyTocc1rbNcRuj/HLA==",
+   "version": "1.3.340",
+   "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz",
+   "integrity": "sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==",
    "dev": true
   },
   "emoji-regex": {
@@ -3518,6 +3824,13 @@
    "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
    "dev": true
   },
+  "file-uri-to-path": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+   "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+   "dev": true,
+   "optional": true
+  },
   "fill-range": {
    "version": "4.0.0",
    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3667,14 +3980,15 @@
    "dev": true
   },
   "fsevents": {
-   "version": "1.2.9",
-   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-   "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+   "version": "1.2.11",
+   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+   "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
    "dev": true,
    "optional": true,
    "requires": {
+    "bindings": "^1.5.0",
     "nan": "^2.12.1",
-    "node-pre-gyp": "^0.12.0"
+    "node-pre-gyp": "*"
    },
    "dependencies": {
     "abbrev": {
@@ -3722,7 +4036,7 @@
      }
     },
     "chownr": {
-     "version": "1.1.1",
+     "version": "1.1.3",
      "bundled": true,
      "dev": true,
      "optional": true
@@ -3752,7 +4066,7 @@
      "optional": true
     },
     "debug": {
-     "version": "4.1.1",
+     "version": "3.2.6",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -3779,12 +4093,12 @@
      "optional": true
     },
     "fs-minipass": {
-     "version": "1.2.5",
+     "version": "1.2.7",
      "bundled": true,
      "dev": true,
      "optional": true,
      "requires": {
-      "minipass": "^2.2.1"
+      "minipass": "^2.6.0"
      }
     },
     "fs.realpath": {
@@ -3810,7 +4124,7 @@
      }
     },
     "glob": {
-     "version": "7.1.3",
+     "version": "7.1.6",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -3839,7 +4153,7 @@
      }
     },
     "ignore-walk": {
-     "version": "3.0.1",
+     "version": "3.0.3",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -3858,7 +4172,7 @@
      }
     },
     "inherits": {
-     "version": "2.0.3",
+     "version": "2.0.4",
      "bundled": true,
      "dev": true,
      "optional": true
@@ -3900,7 +4214,7 @@
      "optional": true
     },
     "minipass": {
-     "version": "2.3.5",
+     "version": "2.9.0",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -3910,12 +4224,12 @@
      }
     },
     "minizlib": {
-     "version": "1.2.1",
+     "version": "1.3.3",
      "bundled": true,
      "dev": true,
      "optional": true,
      "requires": {
-      "minipass": "^2.2.1"
+      "minipass": "^2.9.0"
      }
     },
     "mkdirp": {
@@ -3928,24 +4242,24 @@
      }
     },
     "ms": {
-     "version": "2.1.1",
+     "version": "2.1.2",
      "bundled": true,
      "dev": true,
      "optional": true
     },
     "needle": {
-     "version": "2.3.0",
+     "version": "2.4.0",
      "bundled": true,
      "dev": true,
      "optional": true,
      "requires": {
-      "debug": "^4.1.0",
+      "debug": "^3.2.6",
       "iconv-lite": "^0.4.4",
       "sax": "^1.2.4"
      }
     },
     "node-pre-gyp": {
-     "version": "0.12.0",
+     "version": "0.14.0",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -3959,7 +4273,7 @@
       "rc": "^1.2.7",
       "rimraf": "^2.6.1",
       "semver": "^5.3.0",
-      "tar": "^4"
+      "tar": "^4.4.2"
      }
     },
     "nopt": {
@@ -3973,13 +4287,22 @@
      }
     },
     "npm-bundled": {
-     "version": "1.0.6",
+     "version": "1.1.1",
+     "bundled": true,
+     "dev": true,
+     "optional": true,
+     "requires": {
+      "npm-normalize-package-bin": "^1.0.1"
+     }
+    },
+    "npm-normalize-package-bin": {
+     "version": "1.0.1",
      "bundled": true,
      "dev": true,
      "optional": true
     },
     "npm-packlist": {
-     "version": "1.4.1",
+     "version": "1.4.7",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -4050,7 +4373,7 @@
      "optional": true
     },
     "process-nextick-args": {
-     "version": "2.0.0",
+     "version": "2.0.1",
      "bundled": true,
      "dev": true,
      "optional": true
@@ -4091,7 +4414,7 @@
      }
     },
     "rimraf": {
-     "version": "2.6.3",
+     "version": "2.7.1",
      "bundled": true,
      "dev": true,
      "optional": true,
@@ -4118,7 +4441,7 @@
      "optional": true
     },
     "semver": {
-     "version": "5.7.0",
+     "version": "5.7.1",
      "bundled": true,
      "dev": true,
      "optional": true
@@ -4171,18 +4494,18 @@
      "optional": true
     },
     "tar": {
-     "version": "4.4.8",
+     "version": "4.4.13",
      "bundled": true,
      "dev": true,
      "optional": true,
      "requires": {
       "chownr": "^1.1.1",
       "fs-minipass": "^1.2.5",
-      "minipass": "^2.3.4",
-      "minizlib": "^1.1.1",
+      "minipass": "^2.8.6",
+      "minizlib": "^1.2.1",
       "mkdirp": "^0.5.0",
       "safe-buffer": "^5.1.2",
-      "yallist": "^3.0.2"
+      "yallist": "^3.0.3"
      }
     },
     "util-deprecate": {
@@ -4207,7 +4530,7 @@
      "optional": true
     },
     "yallist": {
-     "version": "3.0.3",
+     "version": "3.1.1",
      "bundled": true,
      "dev": true,
      "optional": true
@@ -4226,10 +4549,16 @@
    "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
    "dev": true
   },
+  "gensync": {
+   "version": "1.0.0-beta.1",
+   "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+   "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+   "dev": true
+  },
   "get-own-enumerable-property-symbols": {
-   "version": "3.0.1",
-   "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
-   "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+   "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
    "dev": true
   },
   "get-stdin": {
@@ -5219,12 +5548,6 @@
     }
    }
   },
-  "js-levenshtein": {
-   "version": "1.1.6",
-   "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-   "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-   "dev": true
-  },
   "js-tokens": {
    "version": "4.0.0",
    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5323,9 +5646,9 @@
    }
   },
   "kind-of": {
-   "version": "6.0.2",
-   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-   "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+   "version": "6.0.3",
+   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+   "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
    "dev": true
   },
   "latest-version": {
@@ -5335,6 +5658,21 @@
    "dev": true,
    "requires": {
     "package-json": "^6.3.0"
+   }
+  },
+  "leven": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+   "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+   "dev": true
+  },
+  "levenary": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
+   "integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
+   "dev": true,
+   "requires": {
+    "leven": "^3.1.0"
    }
   },
   "levn": {
@@ -5460,9 +5798,9 @@
    }
   },
   "magic-string": {
-   "version": "0.25.4",
-   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
-   "integrity": "sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==",
+   "version": "0.25.6",
+   "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
+   "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==",
    "dev": true,
    "requires": {
     "sourcemap-codec": "^1.4.4"
@@ -5677,9 +6015,9 @@
    "dev": true
   },
   "node-releases": {
-   "version": "1.1.41",
-   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
-   "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
+   "version": "1.1.47",
+   "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+   "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
    "dev": true,
    "requires": {
     "semver": "^6.3.0"
@@ -6318,9 +6656,9 @@
    }
   },
   "readable-stream": {
-   "version": "2.3.6",
-   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-   "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+   "version": "2.3.7",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+   "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
    "dev": true,
    "requires": {
     "core-util-is": "~1.0.0",
@@ -6414,13 +6752,12 @@
    }
   },
   "registry-auth-token": {
-   "version": "4.0.0",
-   "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
-   "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+   "version": "4.1.1",
+   "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+   "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
    "dev": true,
    "requires": {
-    "rc": "^1.2.8",
-    "safe-buffer": "^5.0.1"
+    "rc": "^1.2.8"
    }
   },
   "registry-url": {
@@ -6439,9 +6776,9 @@
    "dev": true
   },
   "regjsparser": {
-   "version": "0.6.0",
-   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-   "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+   "version": "0.6.2",
+   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+   "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
    "dev": true,
    "requires": {
     "jsesc": "~0.5.0"
@@ -6541,9 +6878,9 @@
    }
   },
   "rollup": {
-   "version": "1.27.6",
-   "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.6.tgz",
-   "integrity": "sha512-/NA1sjU92K9KZHiPdrHMzykFABcjeDaxS8xh19hYj8FKbtGNEahbXkdYatlk75dZF0oRXwzA9KIjHedcxcnYng==",
+   "version": "1.30.1",
+   "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.30.1.tgz",
+   "integrity": "sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==",
    "dev": true,
    "requires": {
     "@types/estree": "*",
@@ -6589,9 +6926,9 @@
      "dev": true
     },
     "resolve": {
-     "version": "1.13.1",
-     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-     "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+     "version": "1.15.0",
+     "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+     "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
      "dev": true,
      "requires": {
       "path-parse": "^1.0.6"
@@ -6610,16 +6947,38 @@
    }
   },
   "rollup-plugin-terser": {
-   "version": "5.1.2",
-   "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
-   "integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
+   "version": "5.2.0",
+   "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.2.0.tgz",
+   "integrity": "sha512-jQI+nYhtDBc9HFRBz8iGttQg7li9klmzR62RG2W2nN6hJ/FI2K2ItYQ7kJ7/zn+vs+BP1AEccmVRjRN989I+Nw==",
    "dev": true,
    "requires": {
-    "@babel/code-frame": "^7.0.0",
-    "jest-worker": "^24.6.0",
-    "rollup-pluginutils": "^2.8.1",
-    "serialize-javascript": "^1.7.0",
-    "terser": "^4.1.0"
+    "@babel/code-frame": "^7.5.5",
+    "jest-worker": "^24.9.0",
+    "rollup-pluginutils": "^2.8.2",
+    "serialize-javascript": "^2.1.2",
+    "terser": "^4.6.2"
+   },
+   "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+     "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.8.3"
+     }
+    },
+    "@babel/highlight": {
+     "version": "7.8.3",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+     "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+     "dev": true,
+     "requires": {
+      "chalk": "^2.0.0",
+      "esutils": "^2.0.2",
+      "js-tokens": "^4.0.0"
+     }
+    }
    }
   },
   "rollup-pluginutils": {
@@ -6698,9 +7057,9 @@
    }
   },
   "serialize-javascript": {
-   "version": "1.9.1",
-   "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-   "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+   "version": "2.1.2",
+   "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+   "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
    "dev": true
   },
   "set-value": {
@@ -6898,12 +7257,12 @@
    "dev": true
   },
   "source-map-resolve": {
-   "version": "0.5.2",
-   "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-   "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+   "version": "0.5.3",
+   "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+   "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
    "dev": true,
    "requires": {
-    "atob": "^2.1.1",
+    "atob": "^2.1.2",
     "decode-uri-component": "^0.2.0",
     "resolve-url": "^0.2.1",
     "source-map-url": "^0.4.0",
@@ -6935,9 +7294,9 @@
    "dev": true
   },
   "sourcemap-codec": {
-   "version": "1.4.6",
-   "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-   "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+   "version": "1.4.8",
+   "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+   "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
    "dev": true
   },
   "spdx-correct": {
@@ -7071,10 +7430,14 @@
    }
   },
   "strip-comments": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
-   "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
-   "dev": true
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+   "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+   "dev": true,
+   "requires": {
+    "babel-extract-comments": "^1.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0"
+   }
   },
   "strip-eof": {
    "version": "1.0.0",
@@ -7178,9 +7541,9 @@
    }
   },
   "terser": {
-   "version": "4.4.0",
-   "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
-   "integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
+   "version": "4.6.3",
+   "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+   "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
    "dev": true,
    "requires": {
     "commander": "^2.20.0",
@@ -7515,27 +7878,27 @@
    "dev": true
   },
   "workbox-background-sync": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.0.0-rc.1.tgz",
-   "integrity": "sha512-XqOckIvS7g+w17IzlRbB+oaqdcWlcWz2HuoZfN7kdQ1EUkJV8URLh4fUR56iPw3n5P08/Stw0lGOEqrYJNDVdQ==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.0.0-rc.2.tgz",
+   "integrity": "sha512-+tICFPevxh3R7qrLlL9RYlZqcMyR7h75AWsxhkzVm+W+kWt5+5azB1/KVR4NgVdOr8gKOaG+vVhrF5zjv9/1BQ==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-broadcast-update": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.0.0-rc.1.tgz",
-   "integrity": "sha512-h+0muLrSSyibIwNybdoVxBmeLM3r6RcD4Q0/bphkBHz786WT5xMJV5EUK1bZQfiUR5D90dhnp+R8w8z6MFe3PA==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.0.0-rc.2.tgz",
+   "integrity": "sha512-1QurYVHiTmo02e4mElEO8k7RQ6YIUmcJEBwgnmrAJDoVjigdZjHX/32KXy4vB/CS3tHxEQ1lGg1BkhhK7sQNmQ==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-build": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-5.0.0-rc.1.tgz",
-   "integrity": "sha512-/souHRM/vMgF/9nM0zdpfWF/9n8Q2AUThpry5dMZw34HUMK+FHEmv4uYUrNdf3fIjQtfxv1jIZ6YBtL0W5Sj4g==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-5.0.0-rc.2.tgz",
+   "integrity": "sha512-2IlfOEXJ+5jV28xwuGvL6I/+9kDNJ2hjSSLJ2MLjwQeana5swfMwV/v9AvoPW3qzVVmPkeejl65ca+ShZGfcWg==",
    "dev": true,
    "requires": {
     "@babel/core": "^7.5.5",
@@ -7557,23 +7920,23 @@
     "source-map": "^0.7.3",
     "source-map-url": "^0.4.0",
     "stringify-object": "^3.3.0",
-    "strip-comments": "^2.0.1",
+    "strip-comments": "^1.0.2",
     "tempy": "^0.3.0",
     "upath": "^1.1.2",
-    "workbox-background-sync": "^5.0.0-rc.1",
-    "workbox-broadcast-update": "^5.0.0-rc.1",
-    "workbox-cacheable-response": "^5.0.0-rc.1",
-    "workbox-core": "^5.0.0-rc.1",
-    "workbox-expiration": "^5.0.0-rc.1",
-    "workbox-google-analytics": "^5.0.0-rc.1",
-    "workbox-navigation-preload": "^5.0.0-rc.1",
-    "workbox-precaching": "^5.0.0-rc.1",
-    "workbox-range-requests": "^5.0.0-rc.1",
-    "workbox-routing": "^5.0.0-rc.1",
-    "workbox-strategies": "^5.0.0-rc.1",
-    "workbox-streams": "^5.0.0-rc.1",
-    "workbox-sw": "^5.0.0-rc.1",
-    "workbox-window": "^5.0.0-rc.1"
+    "workbox-background-sync": "^5.0.0-rc.2",
+    "workbox-broadcast-update": "^5.0.0-rc.2",
+    "workbox-cacheable-response": "^5.0.0-rc.2",
+    "workbox-core": "^5.0.0-rc.2",
+    "workbox-expiration": "^5.0.0-rc.2",
+    "workbox-google-analytics": "^5.0.0-rc.2",
+    "workbox-navigation-preload": "^5.0.0-rc.2",
+    "workbox-precaching": "^5.0.0-rc.2",
+    "workbox-range-requests": "^5.0.0-rc.2",
+    "workbox-routing": "^5.0.0-rc.2",
+    "workbox-strategies": "^5.0.0-rc.2",
+    "workbox-streams": "^5.0.0-rc.2",
+    "workbox-sw": "^5.0.0-rc.2",
+    "workbox-window": "^5.0.0-rc.2"
    },
    "dependencies": {
     "glob": {
@@ -7599,18 +7962,18 @@
    }
   },
   "workbox-cacheable-response": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.0.0-rc.1.tgz",
-   "integrity": "sha512-L7eP1rTgO+tG1g0BxAk0vWQ3ao7MlYnMD7d9uq3MB6H9/s3DNvdDU3XRcSS4CfqtekkdDJ9cKF+trF/nlVPHiQ==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.0.0-rc.2.tgz",
+   "integrity": "sha512-5fGLLRBlKOWJdYdOCc1O1FmaEQBzizqelVIjkyUt0aytll/nDAsUnRbCXeY7ReTwcFAZaYZoBiJ14Vg6bTqOHw==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-cli": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-cli/-/workbox-cli-5.0.0-rc.1.tgz",
-   "integrity": "sha512-u2BJY56iJeZhNqJ7GMzixJwflVB3bpI2OychXu1zJVlf+bgdB7TsJ0FAFUsL0vbgLsgFk+AGv4ZZUV/alL//uA==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-cli/-/workbox-cli-5.0.0-rc.2.tgz",
+   "integrity": "sha512-EXgc/+tsBKpX+WC+EtoZYgEcoVTsIJOSWcAgOoP+amoiSRQYVaG9t6lEmeNCXCtzVO8F+J5yERPdXyLgeii+Xw==",
    "dev": true,
    "requires": {
     "@babel/runtime": "^7.5.5",
@@ -7625,7 +7988,7 @@
     "pretty-bytes": "^5.2.0",
     "upath": "^1.1.2",
     "update-notifier": "^3.0.1",
-    "workbox-build": "^5.0.0-rc.1"
+    "workbox-build": "^5.0.0-rc.2"
    },
    "dependencies": {
     "ansi-regex": {
@@ -7851,101 +8214,101 @@
    }
   },
   "workbox-core": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.0.0-rc.1.tgz",
-   "integrity": "sha512-359e57sA0yVExt0ezwg8s4TlM1E6O3DP8hJJjD6onyCmwgykK0vvKsDn+FkCbxsCzecSQNwsnUaUAbg9L84WMw==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.0.0-rc.2.tgz",
+   "integrity": "sha512-YCJrOC+2+0nA+d247jHhuym6QiAvzIBT7Clg+hxT5FelijXzXs0zML1VedALNEMobYoqPfIG8hFra0vp7zBImg==",
    "dev": true
   },
   "workbox-expiration": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.0.0-rc.1.tgz",
-   "integrity": "sha512-ttAIu/VYg8m1s53Lk0NbXluLUFe249ktZlqzkzvCZIwWUzGr/ss3/E+VPOxQtVBskACBgr7/aaSbMnRKSXQbUQ==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.0.0-rc.2.tgz",
+   "integrity": "sha512-hk2cN3q/CwwREBHz8M5HLxX+zFBxj55WzcD/kMOBQH9q29BT8obn2mUImlfLHSflDujPjZkEsqJ5aHOMQciO+w==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-google-analytics": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.0.0-rc.1.tgz",
-   "integrity": "sha512-IGwugTlP4FK2RqZc/0ZKDglNfkgNrTRcIAQMB2tngDazP3Yj4scNxyka1rphugB8ivIapdk9x+vQzOkiGLNUzA==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.0.0-rc.2.tgz",
+   "integrity": "sha512-tMxjb9pNDR+bXGABiNEygcafjH/cmYDPKkiIXE65zlVBsflQWp5niQa0H2xyaKiND15Ox2pwkYBWHX2vNnoUQw==",
    "dev": true,
    "requires": {
-    "workbox-background-sync": "^5.0.0-rc.1",
-    "workbox-core": "^5.0.0-rc.1",
-    "workbox-routing": "^5.0.0-rc.1",
-    "workbox-strategies": "^5.0.0-rc.1"
+    "workbox-background-sync": "^5.0.0-rc.2",
+    "workbox-core": "^5.0.0-rc.2",
+    "workbox-routing": "^5.0.0-rc.2",
+    "workbox-strategies": "^5.0.0-rc.2"
    }
   },
   "workbox-navigation-preload": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.0.0-rc.1.tgz",
-   "integrity": "sha512-f53/WY62NGa9Kw3VQAnJDCNShBMO4BbDsUAgz7fvbvsylo0hZSxBSYYF2zaggKzYG7LhP7qJcAaA9pCe8jEK2A==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.0.0-rc.2.tgz",
+   "integrity": "sha512-/eLBbK2u/PUCN6bGjHRC+jS9bVhx9DZ9tAJG24F6lPLApz4f9l+ui+THvVbd3t8zpspYgaE9SkDxj1+p0U8LfA==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-precaching": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.0.0-rc.1.tgz",
-   "integrity": "sha512-7o1iCeS4nG2nhIJ0b0bjiBD9JmGb09C2tt5b1x6tS3z6bYjPpfOvfdK4+JGx9MqH4E/m9uNqhULvWikDm7WD9g==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.0.0-rc.2.tgz",
+   "integrity": "sha512-o29Y4LkL0eRQZWF6+QxQXLHSwT0l04PUORfPC4wrIZqkPEDdT77af69OvNy97ISOvJJiwl+xa+7FR2DEirUOgA==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-range-requests": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.0.0-rc.1.tgz",
-   "integrity": "sha512-2bav5EfdgMjiM8QZ5LMTHTqtCDlxyGJSmMDKt4GFTRABx18c/GnWcAUpmHywLBvEKj9eRSpKGAbCavuFoGXUdg==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.0.0-rc.2.tgz",
+   "integrity": "sha512-UxadVPjHnbi7b1lQBAwUTICPwcR2TaXupmrPM8DFNJ5zKMl5wZ1t2TcdQjSuFHDyIp7xtDCuwxUgbeGD34uIbA==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-routing": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.0.0-rc.1.tgz",
-   "integrity": "sha512-jfpWMjyWehadR07Dx6DFTBvPCb+erJgdtJCq7VUiA64GFuZaHUiGJS7wguG46ivPom9owK0KA+gEMunSZOBZ2A==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.0.0-rc.2.tgz",
+   "integrity": "sha512-h093FLa29SFBgvc+7ZBJo9nPfX/t2pIY6SqiuAF0pYZxFGahpjVAL+K8bHrwl8V36cv0DyEqZFbAeDgwrNj1lg==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "workbox-strategies": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.0.0-rc.1.tgz",
-   "integrity": "sha512-qx+X4QpPsnrWEUhxoniPjng5YXuUUVTubyc3a67kGCv1w0aUxDArjctE1tBoOnPCDVr0CgER4YHingUNFVH3TQ==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.0.0-rc.2.tgz",
+   "integrity": "sha512-7j78DmikesKLiSv7UFYzBE/Oa18v+9QNPnzdmyDF/2bROLSGj8+5wADw8xtRArUVRRC9HnDVf7u53fH8HRywIQ==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1",
-    "workbox-routing": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2",
+    "workbox-routing": "^5.0.0-rc.2"
    }
   },
   "workbox-streams": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.0.0-rc.1.tgz",
-   "integrity": "sha512-ya0tAvTLOmpaLWiS6Ojd3GYSrJurwPUNaA4l/4X7pzt2Hi2Vdb2CDYieFEscnlMJpALGAJAE826hIKextFWsEw==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.0.0-rc.2.tgz",
+   "integrity": "sha512-4UsbdbdtzQ3bdeMC9KnBm8vy4ZGR2X77xEmIGgtD0dnWeWq/+AVdTAu6yP+HvCGDjYUieTFusRU9IPJbcMnJzQ==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1",
-    "workbox-routing": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2",
+    "workbox-routing": "^5.0.0-rc.2"
    }
   },
   "workbox-sw": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.0.0-rc.1.tgz",
-   "integrity": "sha512-ksmoDsGohjRabauezCdILNiJBdsqHtksfPpVjcD3OylFU4nuutJn6Gch0wGBFd7dPYCjJ9uN9rPAwkBeJF7KBg==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.0.0-rc.2.tgz",
+   "integrity": "sha512-Un62O/JT9syuzmN2zFVpFn+lBVEV9e6McT1wpHKGkmuEi79N4z3kduYUsCQNyG9B9nrpzOMZ4NkEHY4ghnct2w==",
    "dev": true
   },
   "workbox-window": {
-   "version": "5.0.0-rc.1",
-   "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.0.0-rc.1.tgz",
-   "integrity": "sha512-yzu+pglRubl3DGuxFC3TmmsLWgE+v62+sH4m3JfA6xXMLIO9tXp7yLlFnyPM+tW+a7Roq2cebC5940Nd1GY3Tw==",
+   "version": "5.0.0-rc.2",
+   "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.0.0-rc.2.tgz",
+   "integrity": "sha512-03PBfUlVWaBtuIG2SPoZQFV+GZM1bGEP4WOR4o7O5VyeFjQE5Zy3DzNYsOoC3oNXtimmpBaAG5/R4tEd3TaWrA==",
    "dev": true,
    "requires": {
-    "workbox-core": "^5.0.0-rc.1"
+    "workbox-core": "^5.0.0-rc.2"
    }
   },
   "wrappy": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "grunt-shell": "3.0.1",
   "grunt-wp-deploy": "2.0.0",
   "husky": "3.0.0",
-  "workbox-cli": "5.0.0-rc.1"
+  "workbox-cli": "5.0.0-rc.2"
  },
  "scripts": {
   "pre-commit": "if command -v lando >/dev/null 2>&1; then lando ssh -c 'bash ./vendor/xwp/wp-dev-lib/scripts/pre-commit'; else ./vendor/xwp/wp-dev-lib/scripts/pre-commit; fi",


### PR DESCRIPTION
See https://github.com/GoogleChrome/workbox/releases/tag/v5.0.0-rc.2

Of note, the `wp_service_worker_navigation_route_blacklist_patterns` filter has been deprecated in favor of `wp_service_worker_navigation_route_denylist_patterns`. See https://github.com/GoogleChrome/workbox/pull/2325.