### PR TITLE
Omit code specific to Google Analytics

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
 			},
 			install_workbox: {
 				command:
-					'if [ -e wp-includes/js/workbox* ]; then rm -r wp-includes/js/workbox*; fi; npx workbox copyLibraries wp-includes/js/',
+					'if [ -e wp-includes/js/workbox* ]; then rm -r wp-includes/js/workbox*; fi; npx workbox copyLibraries wp-includes/js/; rm wp-includes/js/workbox*/workbox-offline-ga*',
 			},
 			create_build_zip: {
 				command:


### PR DESCRIPTION
The Google Analytics integration should not be part of WordPress core and thus not part of the PWA plugin. To achieve integration with Google Analytics, the code should be added to the service worker by another plugin that is responsible for Google Analytics (e.g. [Site Kit](https://github.com/google/site-kit-wp/)).

- [x] Omit the `workbox-offline-ga` module.
- [ ] Omit Google Analytics cache name logic from `workbox-core`
- [ ] Omit Google Analytics from `workbox-sw` lazy-loading logic.