### PR TITLE
Replace ~master~ with develop (Happy Juneteenth!)

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -6,3 +6,4 @@ if [[ ! -z $TRAVIS ]]; then
 	CHECK_SCOPE=all
 fi
 CHECK_SCOPE=all
+DEFAULT_BASE_BRANCH=develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
 
 branches:
   only:
-    - master
+    - develop
 
 install:
   - composer install

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ WordPress feature plugin to bring Progressive Web App (PWA) capabilities to Core
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Requires PHP:** 5.6  
 
-[![Build Status](https://travis-ci.com/GoogleChromeLabs/pwa-wp.svg?branch=master)](https://travis-ci.com/GoogleChromeLabs/pwa-wp) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 
+[![Build Status](https://travis-ci.com/GoogleChromeLabs/pwa-wp.svg?branch=develop)](https://travis-ci.com/GoogleChromeLabs/pwa-wp) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 
 
 ## Description ##
 


### PR DESCRIPTION
I've already created a `develop` branch and re-pointed the open PRs to that branch.

I've already changed the default base branch to `develop` in the repo settings.

Once this PR is merged, the ~`master`~ branch can be eliminated.

cf. [proposal](https://make.wordpress.org/core/2020/06/18/proposal-update-all-git-repositories-to-use-main-instead-of-master/) on WordPress Make/Core 


