### PR TITLE
Allow HTTPS detection and UI to be disabled

### DIFF
--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -39,6 +39,12 @@ class WP_HTTPS_Detection {
 	const INSECURE_CONTENT_OPTION_NAME = 'insecure_content';
 
 	/**
+	 * Filter tag to disable HTTPS detection and UI, such as when redirection is
+	 * handled outside of WordPress.
+	 */
+	const FILTER_DISABLE = 'wp_https_detection_ui_disabled';
+
+	/**
 	 * The tag names for insecure content.
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content
@@ -57,6 +63,10 @@ class WP_HTTPS_Detection {
 	 * Initializes the object.
 	 */
 	public function init() {
+		if ( apply_filters( self::FILTER_DISABLE, false ) ) {
+			return;
+		}
+
 		add_action( 'init', array( $this, 'schedule_cron' ) );
 		add_action( self::CRON_HOOK, array( $this, 'update_https_support_options' ) );
 		add_filter( 'cron_request', array( $this, 'conditionally_prevent_sslverify' ), PHP_INT_MAX );

--- a/wp-includes/class-wp-https-detection.php
+++ b/wp-includes/class-wp-https-detection.php
@@ -39,12 +39,6 @@ class WP_HTTPS_Detection {
 	const INSECURE_CONTENT_OPTION_NAME = 'insecure_content';
 
 	/**
-	 * Filter tag to disable HTTPS detection and UI, such as when redirection is
-	 * handled outside of WordPress.
-	 */
-	const FILTER_DISABLE = 'wp_https_detection_ui_disabled';
-
-	/**
 	 * The tag names for insecure content.
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content
@@ -63,7 +57,13 @@ class WP_HTTPS_Detection {
 	 * Initializes the object.
 	 */
 	public function init() {
-		if ( apply_filters( self::FILTER_DISABLE, false ) ) {
+		/**
+		 * Filter tag to disable HTTPS detection and UI, such as when redirection
+		 * is handled outside of WordPress.
+		 *
+		 * @param bool $disabled Disable detection and UI.
+		 */
+		if ( apply_filters( 'wp_https_detection_ui_disabled', false ) ) {
 			return;
 		}
 

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -79,6 +79,10 @@ class WP_HTTPS_UI {
 	 * Initializes the object.
 	 */
 	public function init() {
+		if ( apply_filters( WP_HTTPS_Detection::FILTER_DISABLE, false ) ) {
+			return;
+		}
+
 		add_action( 'admin_init', array( $this, 'init_admin' ) );
 		add_action( 'init', array( $this, 'filter_site_url_and_home' ) );
 		add_action( 'init', array( $this, 'filter_header' ) );

--- a/wp-includes/class-wp-https-ui.php
+++ b/wp-includes/class-wp-https-ui.php
@@ -79,7 +79,8 @@ class WP_HTTPS_UI {
 	 * Initializes the object.
 	 */
 	public function init() {
-		if ( apply_filters( WP_HTTPS_Detection::FILTER_DISABLE, false ) ) {
+		/** This filter is documented in wp-includes/class-wp-https-detection.php */
+		if ( apply_filters( 'wp_https_detection_ui_disabled', false ) ) {
 			return;
 		}
 


### PR DESCRIPTION
In cases where HTTPS redirection is handled by the web host, or is otherwise outside of the control of WordPress, the UI and detection can be confusing or superfluous.