### PR TITLE
Update wording of the serverOffline message.

### DIFF
--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -144,7 +144,7 @@ function wp_service_worker_get_error_messages() {
 		'wp_service_worker_error_messages',
 		array(
 			'clientOffline' => __( 'It seems you are offline. Please check your internet connection and try again.', 'pwa' ),
-			'serverOffline' => __( 'The server appears to be down. Please try again later.', 'pwa' ),
+			'serverOffline' => __( 'The server appears to be down, or your connection isn\'t working as expected. Please try again later.', 'pwa' ),
 			'error'         => __( 'Something prevented the page from being rendered. Please try again.', 'pwa' ),
 			'comment'       => __( 'Your comment will be submitted once you are back online!', 'pwa' ),
 		)


### PR DESCRIPTION
The serverOffline message was being shown even though the site was online & working perfectly fine while it was an issue with the client's connection (while they weren't necessarily considered offline.) As such, it should mention both possibilities so people don't instantly blame the website when that might not be the cause for the issue.