### PR TITLE
Correct version handling for precached assets

### DIFF
--- a/integrations/class-wp-service-worker-scripts-integration.php
+++ b/integrations/class-wp-service-worker-scripts-integration.php
@@ -75,16 +75,21 @@ class WP_Service_Worker_Scripts_Integration extends WP_Service_Worker_Base_Integ
 			/** This filter is documented in wp-includes/class.wp-scripts.php */
 			$url = apply_filters( 'script_loader_src', $url, $handle );
 
+			$revision = null;
+			$version  = '';
+
 			if ( null === $dependency->ver ) {
 				$revision = wp_scripts()->default_version;
 			} else {
-				$url = add_query_arg(
-					'ver',
-					$dependency->ver ?: wp_scripts()->default_version,
-					$url
-				);
+				$version = $dependency->ver ? $dependency->ver : wp_scripts()->default_version;
+			}
 
-				$revision = null;
+			if ( isset( wp_scripts()->args[ $handle ] ) ) {
+				$version = $version ? $version . '&amp;' . wp_scripts()->args[ $handle ] : wp_scripts()->args[ $handle ];
+			}
+
+			if ( ! empty( $version ) ) {
+				$url = add_query_arg( 'ver', $version, $url );
 			}
 
 			// @todo Issue a warning when it is not a local file?

--- a/integrations/class-wp-service-worker-scripts-integration.php
+++ b/integrations/class-wp-service-worker-scripts-integration.php
@@ -72,10 +72,20 @@ class WP_Service_Worker_Scripts_Integration extends WP_Service_Worker_Base_Integ
 				$url = wp_scripts()->base_url . $url;
 			}
 
-			$revision = false === $dependency->ver ? get_bloginfo( 'version' ) : $dependency->ver;
-
 			/** This filter is documented in wp-includes/class.wp-scripts.php */
 			$url = apply_filters( 'script_loader_src', $url, $handle );
+
+			if ( null === $dependency->ver ) {
+				$revision = wp_scripts()->default_version;
+			} else {
+				$url = add_query_arg(
+					'ver',
+					$dependency->ver ?: wp_scripts()->default_version,
+					$url
+				);
+
+				$revision = null;
+			}
 
 			// @todo Issue a warning when it is not a local file?
 			if ( $url && $this->is_local_file_url( $url ) ) {

--- a/integrations/class-wp-service-worker-styles-integration.php
+++ b/integrations/class-wp-service-worker-styles-integration.php
@@ -72,10 +72,20 @@ class WP_Service_Worker_Styles_Integration extends WP_Service_Worker_Base_Integr
 				$url = wp_styles()->base_url . $url;
 			}
 
-			$revision = false === $dependency->ver ? get_bloginfo( 'version' ) : $dependency->ver;
-
 			/** This filter is documented in wp-includes/class.wp-styles.php */
 			$url = apply_filters( 'style_loader_src', $url, $handle );
+
+			if ( null === $dependency->ver ) {
+				$revision = wp_styles()->default_version;
+			} else {
+				$url = add_query_arg(
+					'ver',
+					$dependency->ver ?: wp_styles()->default_version,
+					$url
+				);
+
+				$revision = null;
+			}
 
 			// @todo Issue a warning when it is not a local file?
 			if ( is_string( $url ) && $this->is_local_file_url( $url ) ) {

--- a/integrations/class-wp-service-worker-styles-integration.php
+++ b/integrations/class-wp-service-worker-styles-integration.php
@@ -75,16 +75,21 @@ class WP_Service_Worker_Styles_Integration extends WP_Service_Worker_Base_Integr
 			/** This filter is documented in wp-includes/class.wp-styles.php */
 			$url = apply_filters( 'style_loader_src', $url, $handle );
 
+			$revision = null;
+			$version  = '';
+
 			if ( null === $dependency->ver ) {
 				$revision = wp_styles()->default_version;
 			} else {
-				$url = add_query_arg(
-					'ver',
-					$dependency->ver ?: wp_styles()->default_version,
-					$url
-				);
+				$version = $dependency->ver ? $dependency->ver : wp_styles()->default_version;
+			}
 
-				$revision = null;
+			if ( isset( wp_styles()->args[ $handle ] ) ) {
+				$version = $version ? $version . '&amp;' . wp_styles()->args[ $handle ] : wp_styles()->args[ $handle ];
+			}
+
+			if ( ! empty( $version ) ) {
+				$url = add_query_arg( 'ver', $version, $url );
 			}
 
 			// @todo Issue a warning when it is not a local file?


### PR DESCRIPTION
Investigating cache misses for precached assets revealed that the plugin wasn't building URLs in the same way that the `WP_Scripts` and `WP_Styles` classes do. 

The revision handling also contributed to cache misses. Per https://developers.google.com/web/tools/workbox/modules/workbox-precaching#explanation_of_the_precache_list, when the URL includes a version, the revision should be set to `null`.