### PR TITLE
Update the way a navigation route is registered

### DIFF
--- a/wp-includes/js/service-worker-navigation-routing.js
+++ b/wp-includes/js/service-worker-navigation-routing.js
@@ -158,11 +158,15 @@ ERROR_OFFLINE_URL, ERROR_500_URL, NAVIGATION_DENYLIST_PATTERNS, ERROR_MESSAGES *
 		(pattern) => new RegExp(pattern)
 	);
 	if (navigationRouteEntry && navigationRouteEntry.url) {
-		wp.serviceWorker.routing.registerNavigationRoute(
-			navigationRouteEntry.url,
-			{
-				denylist,
-			}
+		wp.serviceWorker.routing.registerRoute(
+			new wp.serviceWorker.routing.NavigationRoute(
+				wp.serviceWorker.precaching.createHandlerBoundToURL(
+					navigationRouteEntry.url
+				),
+				{
+					denylist,
+				}
+			)
 		);
 
 		class FetchNavigationRoute extends wp.serviceWorker.routing.Route {


### PR DESCRIPTION
The way a navigation route is registered changed in Workbox 5 (see: GoogleChrome/workbox#2095).

---

Fixes #319