### PR TITLE
Avoid constructing asset versions with HTML entities in context of SW

### DIFF
--- a/integrations/class-wp-service-worker-scripts-integration.php
+++ b/integrations/class-wp-service-worker-scripts-integration.php
@@ -85,7 +85,7 @@ class WP_Service_Worker_Scripts_Integration extends WP_Service_Worker_Base_Integ
 			}
 
 			if ( isset( wp_scripts()->args[ $handle ] ) ) {
-				$version = $version ? $version . '&amp;' . wp_scripts()->args[ $handle ] : wp_scripts()->args[ $handle ];
+				$version = $version ? $version . '&' . wp_scripts()->args[ $handle ] : wp_scripts()->args[ $handle ];
 			}
 
 			if ( ! empty( $version ) ) {

--- a/integrations/class-wp-service-worker-styles-integration.php
+++ b/integrations/class-wp-service-worker-styles-integration.php
@@ -85,7 +85,7 @@ class WP_Service_Worker_Styles_Integration extends WP_Service_Worker_Base_Integr
 			}
 
 			if ( isset( wp_styles()->args[ $handle ] ) ) {
-				$version = $version ? $version . '&amp;' . wp_styles()->args[ $handle ] : wp_styles()->args[ $handle ];
+				$version = $version ? $version . '&' . wp_styles()->args[ $handle ] : wp_styles()->args[ $handle ];
 			}
 
 			if ( ! empty( $version ) ) {


### PR DESCRIPTION
Follow up on #317.

I realized that in the context of the service worker, the `&amp;` here should be changed to just `&` since the resulting URL will not be output to HTML for the browser to decode `&amp;` back to `&`.