### PR TITLE
Guard against scripts/styles being printed in SW at wp_enqueue_scripts action

### DIFF
--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -117,6 +117,7 @@ class WP_Service_Workers implements WP_Service_Worker_Registry_Aware {
 
 		@header( 'Content-Type: text/javascript; charset=utf-8' ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.NoSilencedErrors.Discouraged
 
+		ob_start(); // Start guarding against themes/plugins printing anything at wp_enqueue_scripts admin_enqueue_scripts.
 		if ( ! is_admin() ) {
 			wp_enqueue_scripts();
 
@@ -144,6 +145,7 @@ class WP_Service_Workers implements WP_Service_Worker_Registry_Aware {
 			 */
 			do_action( 'wp_admin_service_worker', $this->scripts );
 		}
+		ob_end_clean(); // Finish guarding against themes/plugins printing anything at wp_enqueue_scripts admin_enqueue_scripts.
 
 		ob_start();
 		printf( "/* PWA v%s-%s */\n\n", esc_html( PWA_VERSION ), is_admin() ? 'admin' : 'front' );


### PR DESCRIPTION
Fixes #293.

Before with the Astra theme active, the admin service worker was emitting a JS error by starting with:

```js
                        <style class="astra-menu-appearance-style">
                                        #menu-appearance a[href^="edit.php?post_type=astra-"]:before,
                                        #menu-appearance a[href^="themes.php?page=astra-"]:before,
                                        #menu-appearance a[href^="edit.php?post_type=astra_"]:before,
                                        #menu-appearance a[href^="edit-tags.php?taxonomy=bsf_custom_fonts"]:before,
                                        #menu-appearance a[href^="themes.php?page=custom-typekit-fonts"]:before,
                                        #menu-appearance a[href^="edit.php?post_type=bsf-sidebar"]:before {
                                                content: "\21B3";
                                                margin-right: 0.5em;
                                                opacity: 0.5;
                                        }
                                </style>
                                /* PWA v0.6.0-alpha-admin */

/* Note: This file is dynamically generated. To manipulate the contents of this file, use the `wp_admin_service_worker` action in WordPress. /*
```

The reason is that Astra is printing scripts incorrectly at the `admin_enqueue_scripts` action.

WIth this PR, the `<style>` element is removed. This is achieved by starting output buffering before enqueuing scripts