### PR TITLE
Add offline browsing option in Reading settings

### DIFF
--- a/pwa.php
+++ b/pwa.php
@@ -20,7 +20,7 @@
 define( 'PWA_VERSION', '0.6.0-alpha' );
 define( 'PWA_PLUGIN_FILE', __FILE__ );
 define( 'PWA_PLUGIN_DIR', dirname( __FILE__ ) );
-define( 'PWA_WORKBOX_VERSION', json_decode( file_get_contents( PWA_PLUGIN_DIR . '/package.json' ), true )['devDependencies']['workbox-cli'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Replaced with version literal build.
+define( 'PWA_WORKBOX_VERSION', json_decode( file_get_contents( PWA_PLUGIN_DIR . '/package.json' ), true )['devDependencies']['workbox-cli'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents,PHPCompatibility.Syntax.NewFunctionArrayDereferencing.Found -- Replaced with version literal build.
 define( 'PWA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 /**
@@ -96,7 +96,7 @@ function _pwa_print_build_needed_notice() {
 	</div>
 	<?php
 }
-if ( ! file_exists( __DIR__ . '/wp-includes/js/workbox-v' . PWA_WORKBOX_VERSION ) || ! file_exists( __DIR__ . '/wp-includes/js/workbox-v' . PWA_WORKBOX_VERSION . '/workbox-sw.js' ) ) {
+if ( ! file_exists( PWA_PLUGIN_DIR . '/wp-includes/js/workbox-v' . PWA_WORKBOX_VERSION ) || ! file_exists( PWA_PLUGIN_DIR . '/wp-includes/js/workbox-v' . PWA_WORKBOX_VERSION . '/workbox-sw.js' ) ) {
 	add_action( 'admin_notices', '_pwa_print_build_needed_notice' );
 	return;
 }
@@ -298,3 +298,5 @@ $wp_web_app_manifest->init();
 
 $wp_https_detection = new WP_HTTPS_Detection();
 $wp_https_detection->init();
+
+require_once PWA_PLUGIN_DIR . '/wp-admin/options-reading-offline-browsing.php';

--- a/wp-admin/options-reading-offline-browsing.php
+++ b/wp-admin/options-reading-offline-browsing.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Offline browsing field for the reading settings administration panel.
+ *
+ * As part of a core merge, the code in this file would go inside wp-admin/options-reading.php
+ *
+ * @package PWA
+ */
+
+namespace PWA_WP;
+
+/**
+ * Register offline browsing setting.
+ */
+function register_offline_browsing_setting() {
+	register_setting(
+		'reading',
+		'offline_browsing',
+		array(
+			'type'              => 'boolean',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_offline_browsing_setting' );
+
+/**
+ * Register offline browsing setting field.
+ */
+function add_offline_browsing_setting_field() {
+	add_settings_field(
+		'offline_browsing',
+		__( 'Offline browsing', 'pwa' ),
+		__NAMESPACE__ . '\render_offline_browsing_setting_field',
+		'reading'
+	);
+}
+add_action( 'admin_init', __NAMESPACE__ . '\add_offline_browsing_setting_field' );
+
+/**
+ * Render offline browsing setting field.
+ */
+function render_offline_browsing_setting_field() {
+	?>
+	<fieldset>
+		<legend class="screen-reader-text"><span><?php esc_html_e( 'Offline browsing', 'pwa' ); ?> </span></legend>
+		<label for="offline_browsing">
+			<input name="offline_browsing" type="checkbox" id="offline_browsing" value="1" <?php checked( '1', get_option( 'offline_browsing' ) ); ?> />
+			<?php esc_html_e( 'Cache visited pages in the browser so visitors can re-access then when offline.', 'pwa' ); ?>
+		</label>
+		<p class="description">
+			<?php
+			echo wp_kses(
+				__( 'This makes your site dependable regardless of the network. Such reliability is important for the site to be a <a href="https://web.dev/what-are-pwas/" rel="noreferrer noopener" target="_blank">Progressive Web App</a>.', 'pwa' ),
+				array( 'a' => array_fill_keys( array( 'href', 'rel', 'target' ), true ) )
+			);
+			?>
+		</p>
+	</fieldset>
+	<?php
+}

--- a/wp-admin/options-reading-offline-browsing.php
+++ b/wp-admin/options-reading-offline-browsing.php
@@ -64,7 +64,7 @@ function render_offline_browsing_setting_field() {
  * Print admin pointer.
  */
 function print_admin_pointer() {
-	if ( 'options-reading' === get_current_screen()->id ) {
+	if ( 'options-reading' === get_current_screen()->id || ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 

--- a/wp-admin/options-reading-offline-browsing.php
+++ b/wp-admin/options-reading-offline-browsing.php
@@ -46,7 +46,7 @@ function render_offline_browsing_setting_field() {
 		<legend class="screen-reader-text"><span><?php esc_html_e( 'Offline browsing', 'pwa' ); ?> </span></legend>
 		<label for="offline_browsing">
 			<input name="offline_browsing" type="checkbox" id="offline_browsing" value="1" <?php checked( '1', get_option( 'offline_browsing' ) ); ?> />
-			<?php esc_html_e( 'Cache visited pages in the browser so visitors can re-access then when offline.', 'pwa' ); ?>
+			<?php esc_html_e( 'Cache visited pages in the browser so visitors can re-access them when offline.', 'pwa' ); ?>
 		</label>
 		<p class="description">
 			<?php

--- a/wp-admin/options-reading-offline-browsing.php
+++ b/wp-admin/options-reading-offline-browsing.php
@@ -84,7 +84,7 @@ function print_admin_pointer() {
 	wp_print_styles( array( 'wp-pointer' ) );
 
 	$content  = '<h3>' . esc_html__( 'PWA', 'pwa' ) . '</h3>';
-	$content .= '<p>' . esc_html__( 'Offline browsing is now available to enable by default in Reading settings.', 'pwa' ) . '</p>';
+	$content .= '<p>' . esc_html__( 'Offline browsing is now available in Reading settings.', 'pwa' ) . '</p>';
 
 	$args = array(
 		'content'  => $content,
@@ -97,6 +97,12 @@ function print_admin_pointer() {
 	?>
 	<script type="text/javascript">
 		jQuery( function( $ ) {
+			const menuSettingsItem = $( '#menu-settings' );
+			const readingSettingsItem = menuSettingsItem.find( 'li:has( a[href="options-reading.php"] )' );
+			if ( readingSettingsItem.length === 0 ) {
+				return;
+			}
+
 			const options = $.extend( <?php echo wp_json_encode( $args ); ?>, {
 				close: function() {
 					$.post( ajaxurl, {
@@ -106,7 +112,14 @@ function print_admin_pointer() {
 				}
 			});
 
-			$( '#menu-settings' ).first().pointer( options ).pointer( 'open' );
+			let target;
+			if ( menuSettingsItem.hasClass( 'wp-menu-open' ) ) {
+				target = readingSettingsItem;
+			} else {
+				target = menuSettingsItem;
+			}
+
+			target.pointer( options ).pointer( 'open' );
 		} );
 	</script>
 	<?php

--- a/wp-admin/options-reading-offline-browsing.php
+++ b/wp-admin/options-reading-offline-browsing.php
@@ -59,3 +59,57 @@ function render_offline_browsing_setting_field() {
 	</fieldset>
 	<?php
 }
+
+/**
+ * Print admin pointer.
+ */
+function print_admin_pointer() {
+	if ( 'options-reading' === get_current_screen()->id ) {
+		return;
+	}
+
+	if ( get_option( 'offline_browsing' ) ) {
+		return;
+	}
+
+	$pointer = 'pwa_offline_browsing';
+
+	// Use array_flip() for more performant lookup.
+	$dismissed_pointers = explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) );
+	if ( in_array( $pointer, $dismissed_pointers, true ) ) {
+		return;
+	}
+
+	wp_print_scripts( array( 'wp-pointer' ) );
+	wp_print_styles( array( 'wp-pointer' ) );
+
+	$content  = '<h3>' . esc_html__( 'PWA', 'pwa' ) . '</h3>';
+	$content .= '<p>' . esc_html__( 'Offline browsing is now available to enable by default in Reading settings.', 'pwa' ) . '</p>';
+
+	$args = array(
+		'content'  => $content,
+		'position' => array(
+			'align' => 'middle',
+			'edge'  => is_rtl() ? 'right' : 'left',
+		),
+	);
+
+	?>
+	<script type="text/javascript">
+		jQuery( function( $ ) {
+			const options = $.extend( <?php echo wp_json_encode( $args ); ?>, {
+				close: function() {
+					$.post( ajaxurl, {
+						pointer: <?php echo wp_json_encode( $pointer ); ?>,
+						action: 'dismiss-wp-pointer'
+					});
+				}
+			});
+
+			$( '#menu-settings' ).first().pointer( options ).pointer( 'open' );
+		} );
+	</script>
+	<?php
+
+}
+add_action( 'admin_print_footer_scripts', __NAMESPACE__ . '\print_admin_pointer' );

--- a/wp-admin/options-reading-offline-browsing.php
+++ b/wp-admin/options-reading-offline-browsing.php
@@ -64,17 +64,20 @@ function render_offline_browsing_setting_field() {
  * Print admin pointer.
  */
 function print_admin_pointer() {
-	if ( 'options-reading' === get_current_screen()->id || ! current_user_can( 'manage_options' ) ) {
-		return;
-	}
-
-	if ( get_option( 'offline_browsing' ) ) {
+	// Skip showing admin pointer if not relevant.
+	if (
+		get_option( 'offline_browsing' )
+		||
+		'options-reading' === get_current_screen()->id
+		||
+		! current_user_can( 'manage_options' )
+	) {
 		return;
 	}
 
 	$pointer = 'pwa_offline_browsing';
 
-	// Use array_flip() for more performant lookup.
+	// Skip showing admin pointer if dismissed.
 	$dismissed_pointers = explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) );
 	if ( in_array( $pointer, $dismissed_pointers, true ) ) {
 		return;

--- a/wp-includes/class-wp-service-workers.php
+++ b/wp-includes/class-wp-service-workers.php
@@ -76,15 +76,23 @@ class WP_Service_Workers {
 		$this->caching_routes    = new WP_Service_Worker_Caching_Routes();
 
 		$components = array(
-			'configuration'          => new WP_Service_Worker_Configuration_Component(),
-			'navigation_routing'     => new WP_Service_Worker_Navigation_Routing_Component(),
-			'core_asset_caching'     => new WP_Service_Worker_Core_Asset_Caching_Component(),
-			'theme_asset_caching'    => new WP_Service_Worker_Theme_Asset_Caching_Component(),
-			'plugin_asset_caching'   => new WP_Service_Worker_Plugin_Asset_Caching_Component(),
-			'uploaded_image_caching' => new WP_Service_Worker_Uploaded_Image_Caching_Component(),
-			'precaching_routes'      => new WP_Service_Worker_Precaching_Routes_Component( $this->precaching_routes ),
-			'caching_routes'         => new WP_Service_Worker_Caching_Routes_Component( $this->caching_routes ),
+			'configuration'      => new WP_Service_Worker_Configuration_Component(),
+			'precaching_routes'  => new WP_Service_Worker_Precaching_Routes_Component( $this->precaching_routes ),
+			'caching_routes'     => new WP_Service_Worker_Caching_Routes_Component( $this->caching_routes ),
+			'navigation_routing' => new WP_Service_Worker_Navigation_Routing_Component(),
 		);
+
+		if ( get_option( 'offline_browsing' ) ) {
+			$components = array_merge(
+				$components,
+				array(
+					'core_asset_caching'     => new WP_Service_Worker_Core_Asset_Caching_Component(),
+					'theme_asset_caching'    => new WP_Service_Worker_Theme_Asset_Caching_Component(),
+					'plugin_asset_caching'   => new WP_Service_Worker_Plugin_Asset_Caching_Component(),
+					'uploaded_image_caching' => new WP_Service_Worker_Uploaded_Image_Caching_Component(),
+				)
+			);
+		}
 
 		$this->scripts = new WP_Service_Worker_Scripts( $this->caching_routes, $this->precaching_routes, $components );
 	}

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -108,7 +108,11 @@ class WP_Service_Worker_Navigation_Routing_Component implements WP_Service_Worke
 			 */
 			$caching_strategy = apply_filters( 'wp_service_worker_navigation_caching_strategy', '' );
 			if ( empty( $caching_strategy ) ) {
-				$caching_strategy = WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST;
+				if ( get_option( 'offline_browsing' ) ) {
+					$caching_strategy = WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST;
+				} else {
+					$caching_strategy = WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_ONLY;
+				}
 			}
 
 			/**


### PR DESCRIPTION
Fixes #344.

This adds a new **Offline browsing** toggle to the Reading Settings screen:

> ![image](https://user-images.githubusercontent.com/134745/101975819-63f52000-3bf4-11eb-8361-96b1e6d91006.png)

It is _disabled_ by default. When disabled, by default only the offline page and server error page templates will be served to the user (or any other custom rules that the user may have registered such as via the obsolete [Basic Site Caching](https://gist.github.com/westonruter/1a63d052beb579842461f6ad837715fb) plugin). When enabled, then the new default caching strategies are employed which were introduced in https://github.com/GoogleChromeLabs/pwa-wp/pull/338.

When someone updates to this version of a plugin, an admin pointer is displayed displayed to let them know about this feature:

> ![image](https://user-images.githubusercontent.com/134745/101976340-39f22c80-3bf9-11eb-9396-b892630ab61d.png)
