### PR TITLE
Add crossorigin=use-credentials to link[rel=manifest] for sake of Basic Auth

### DIFF
--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -72,7 +72,7 @@ final class WP_Web_App_Manifest {
 	public function manifest_link_and_meta() {
 		$manifest = $this->get_manifest();
 		?>
-		<link rel="manifest" href="<?php echo esc_url( static::get_url() ); ?>">
+		<link rel="manifest" href="<?php echo esc_url( static::get_url() ); ?>" crossorigin="use-credentials">
 		<meta name="theme-color" content="<?php echo esc_attr( $manifest['theme_color'] ); ?>">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
In a [support topic](https://wordpress.org/support/topic/manifest-and-basic-authentication/), it was revealed that the Web App Manifest fails to load when Basic Auth is being used. 

I was able reproduce this with a test plugin:

```php
<?php
/**
 * Plugin Name: Basic Auth
 */


if ( is_admin() || 'cli' === php_sapi_name() ) {
	return;
}

if (
	! isset( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] )
	||
	'admin' !== $_SERVER['PHP_AUTH_USER']
	||
	'password' !== $_SERVER['PHP_AUTH_PW']
) {
	status_header( 401 );
	header( 'WWW-Authenticate: Basic realm="My Realm"' );
	echo "Authorization required";
	exit;
}
```

When loading a page after providing authentication, I got:

> ![image](https://user-images.githubusercontent.com/134745/102682311-7e437680-417d-11eb-87ba-7ace324faed0.png)

When `crossorigin="use-credentials"` was added, however, there was no issue loading the Web App Manifest.

This appears to be the the best practice per https://github.com/w3c/manifest/issues/535#issuecomment-265338307. For more context and explanation for why this is needed (but isn't for `link[rel=stylesheet]`, see https://github.com/w3c/manifest/issues/535#issuecomment-435739223. 

Solution also affirmed in https://github.com/koajs/basic-auth/issues/19#issuecomment-437050887 and https://stackoverflow.com/a/51157352/93579.

If a site doesn't use HTTP Basic Auth, then sending credentials won't make any difference either.