### PR TITLE
Use wp_robots() to prevent indexing the error template on WP≥5.7

### DIFF
--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -17,7 +17,12 @@ add_action( 'wp_ajax_wp_service_worker', 'wp_ajax_wp_service_worker' );
 add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
 add_action( 'parse_query', 'wp_unauthenticate_error_template_requests' );
 
-add_action( 'wp_head', 'wp_add_error_template_no_robots' );
-add_action( 'error_head', 'wp_add_error_template_no_robots' );
+if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '>=' ) ) {
+	add_action( 'error_head', 'wp_robots', 1 ); // To match wp_robots running at wp_head.
+	add_filter( 'wp_robots', 'wp_filter_robots_for_error_template' );
+} else {
+	add_action( 'wp_head', 'wp_add_error_template_no_robots' );
+	add_action( 'error_head', 'wp_add_error_template_no_robots' );
+}
 
 add_action( 'admin_init', 'wp_disable_script_concatenation' );

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -88,8 +88,24 @@ function pwa_get_footer( $name = null ) {
 }
 
 /**
+ * Filter wp_robots to prevent the error template from being indexed.
+ *
+ * @since 0.7
+ *
+ * @param array $robots Robots.
+ * @return array Robots.
+ */
+function wp_filter_robots_for_error_template( $robots ) {
+	if ( is_offline() || is_500() ) {
+		$robots['noindex'] = true;
+	}
+	return $robots;
+}
+
+/**
  * Add no-robots meta tag to error template.
  *
+ * @deprecated Only relevant to WordPress < 5.6.
  * @todo Is this right? Should we add_action when we find out that the filter is present?
  * @see wp_no_robots()
  * @since 0.2


### PR DESCRIPTION
This prevents a `wp_no_robots()` deprecation warning from being raised in WP 5.7-alpha which was introduced in https://github.com/WordPress/wordpress-develop/pull/702.