### PR TITLE
Don't flush rewrite_rules on every admin request

### DIFF
--- a/wp-includes/class-wp.php
+++ b/wp-includes/class-wp.php
@@ -14,8 +14,9 @@
 function pwa_add_rewrite_rules() {
 	global $wp_rewrite;
 	$rewrite_rule_regex = '^wp\.serviceworker$';
+	$rules = $wp_rewrite->wp_rewrite_rules();
 
-	if ( ! isset( $wp_rewrite->extra_rules_top[ $rewrite_rule_regex ] ) ) {
+	if ( ! isset( $rules[ $rewrite_rule_regex ] ) ) {
 		// Note: This logic will not be required as part of core merge since rewrite rules are flushed upon DB upgrade (as long as the DB version is bumped).
 		add_action(
 			'admin_init',

--- a/wp-includes/class-wp.php
+++ b/wp-includes/class-wp.php
@@ -14,7 +14,7 @@
 function pwa_add_rewrite_rules() {
 	global $wp_rewrite;
 	$rewrite_rule_regex = '^wp\.serviceworker$';
-	$rules = $wp_rewrite->wp_rewrite_rules();
+	$rules              = $wp_rewrite->wp_rewrite_rules();
 
 	if ( ! isset( $rules[ $rewrite_rule_regex ] ) ) {
 		// Note: This logic will not be required as part of core merge since rewrite rules are flushed upon DB upgrade (as long as the DB version is bumped).


### PR DESCRIPTION
This PR fixes an issue where `flush_rewrite_rules` is called on every wp-admin pageload.

`$wp_rewrite->extra_rules_top` only includes rules that were registered during the current request. And because `add_rewrite_rule` is called after the logic that checks for the same rule on `extra_rules_top`, it will never exist and _always_ call `flush_rewrite_rules`. 

Instead, I suggest to do the check against `$wp_rewrite->wp_rewrite_rules()`, as that fetches the existing rules from the database.