### PR TITLE
Utilize workbox-window for service worker registration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,15 @@ module.exports = function (grunt) {
 			},
 			install_workbox: {
 				command:
-					'if [ -e wp-includes/js/workbox* ]; then rm -r wp-includes/js/workbox*; fi; npx workbox copyLibraries wp-includes/js/',
+					'if [ -e wp-includes/js/workbox* ]; then ' +
+					'rm -r wp-includes/js/workbox*; ' +
+					'fi; ' +
+					'npx workbox copyLibraries wp-includes/js/;' +
+					// Rename .mjs with .js since servers may not be configured to serve the former as text/javascript.
+					'for mjs in wp-includes/js/workbox*/*.mjs; do ' +
+					'sed "s/\\.mjs/.js/g" "$mjs" > "${mjs%mjs}js";' +
+					'rm $mjs;' +
+					'done;',
 			},
 			create_build_zip: {
 				command:

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -24,5 +24,3 @@ if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '>=' ) ) 
 	add_action( 'wp_head', 'wp_add_error_template_no_robots' );
 	add_action( 'error_head', 'wp_add_error_template_no_robots' );
 }
-
-add_action( 'admin_init', 'wp_disable_script_concatenation' );

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -57,3 +57,30 @@ function wp_service_worker_json_encode( $data ) {
 	_deprecated_function( __FUNCTION__, '0.6', 'wp_json_encode()' );
 	return wp_json_encode( $data, 128 | 64 /* JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES */ );
 }
+
+/**
+ * Disables concatenating scripts to leverage caching the assets via Service Worker instead.
+ *
+ * @deprecated 0.7 No longer used.
+ */
+function wp_disable_script_concatenation() {
+	_deprecated_function( __FUNCTION__, '0.7' );
+
+	global $concatenate_scripts;
+
+	/*
+	 * This cookie is set when the service worker registers successfully, avoiding unnecessary result
+	 * for browsers that don't support service workers. Note that concatenation only applies in the admin,
+	 * for authenticated users without full-page caching.
+	 */
+	if ( isset( $_COOKIE['wordpress_sw_installed'] ) ) {
+		$concatenate_scripts = false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	// phpcs:disable
+	// @todo This is just here for debugging purposes.
+	if ( isset( $_GET['wp_concatenate_scripts'] ) ) {
+		$concatenate_scripts = rest_sanitize_boolean( $_GET['wp_concatenate_scripts'] );
+	}
+	// phpcs:enable
+}

--- a/wp-includes/deprecated.php
+++ b/wp-includes/deprecated.php
@@ -62,6 +62,7 @@ function wp_service_worker_json_encode( $data ) {
  * Disables concatenating scripts to leverage caching the assets via Service Worker instead.
  *
  * @deprecated 0.7 No longer used.
+ * @codeCoverageIgnore
  */
 function wp_disable_script_concatenation() {
 	_deprecated_function( __FUNCTION__, '0.7' );

--- a/wp-includes/js/service-worker.js
+++ b/wp-includes/js/service-worker.js
@@ -16,7 +16,15 @@ wp.serviceWorker = workbox;
  * mechanism for clients to skip waiting if they want to.
  */
 self.addEventListener('message', function (event) {
-	if ('skipWaiting' === event.data.action) {
+	if (!event.data) {
+		return;
+	}
+	if (
+		// De facto standard used by Workbox.
+		event.data.type === 'SKIP_WAITING' ||
+		// Obsolete message sent in older versions of the plugin.
+		'skipWaiting' === event.data.action
+	) {
 		self.skipWaiting();
 	}
 });

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -188,10 +188,8 @@ function wp_print_service_workers() {
 				<?php echo wp_json_encode( $sw_src ) ?>,
 				<?php echo wp_json_encode( $register_options ) ?>
 			);
-			// @todo Allow clients to register event listeners here.
 			window.wp.serviceWorkerWindow.register();
 		}
-
 	</script>
 	<?php
 	// phpcs:enable Squiz.PHP.EmbeddedPhp.NoSemicolon

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -177,7 +177,6 @@ function wp_print_service_workers() {
 		'scope' => $scope,
 	);
 
-	// phpcs:disable Squiz.PHP.EmbeddedPhp.NoSemicolon
 	?>
 	<script type="module">
 		import { Workbox } from <?php echo wp_json_encode( $workbox_window_src ); ?>;
@@ -185,14 +184,13 @@ function wp_print_service_workers() {
 		if ( 'serviceWorker' in navigator ) {
 			window.wp = window.wp || {};
 			window.wp.serviceWorkerWindow = new Workbox(
-				<?php echo wp_json_encode( $sw_src ) ?>,
-				<?php echo wp_json_encode( $register_options ) ?>
+				<?php echo wp_json_encode( $sw_src ); ?>,
+				<?php echo wp_json_encode( $register_options ); ?>
 			);
 			window.wp.serviceWorkerWindow.register();
 		}
 	</script>
 	<?php
-	// phpcs:enable Squiz.PHP.EmbeddedPhp.NoSemicolon
 }
 
 /**

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -167,7 +167,12 @@ function wp_print_service_workers() {
 		return;
 	}
 
-	$workbox_window_src = sprintf( '%s/wp-includes/js/workbox-v%s/workbox-window.%s.js', PWA_PLUGIN_URL, PWA_WORKBOX_VERSION, SCRIPT_DEBUG ? 'dev' : 'prod' );
+	$workbox_window_src = sprintf(
+		'%s/wp-includes/js/workbox-v%s/workbox-window.%s.js',
+		PWA_PLUGIN_URL,
+		PWA_WORKBOX_VERSION,
+		SCRIPT_DEBUG ? 'dev' : 'prod'
+	);
 	$register_options   = array(
 		'scope' => $scope,
 	);
@@ -177,7 +182,6 @@ function wp_print_service_workers() {
 	<script type="module">
 		import { Workbox } from <?php echo wp_json_encode( $workbox_window_src ); ?>;
 
-		// @todo Defer to load event?
 		if ( 'serviceWorker' in navigator ) {
 			window.wp = window.wp || {};
 			window.wp.serviceWorkerWindow = new Workbox(

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -229,29 +229,6 @@ function wp_ajax_wp_service_worker() {
 }
 
 /**
- * Disables concatenating scripts to leverage caching the assets via Service Worker instead.
- */
-function wp_disable_script_concatenation() {
-	global $concatenate_scripts;
-
-	/*
-	 * This cookie is set when the service worker registers successfully, avoiding unnecessary result
-	 * for browsers that don't support service workers. Note that concatenation only applies in the admin,
-	 * for authenticated users without full-page caching.
-	*/
-	if ( isset( $_COOKIE['wordpress_sw_installed'] ) ) {
-		$concatenate_scripts = false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-	}
-
-	// phpcs:disable
-	// @todo This is just here for debugging purposes.
-	if ( isset( $_GET['wp_concatenate_scripts'] ) ) {
-		$concatenate_scripts = rest_sanitize_boolean( $_GET['wp_concatenate_scripts'] );
-	}
-	// phpcs:enable
-}
-
-/**
  * Checks if Service Worker should skip waiting in case of update and update automatically.
  *
  * @since 0.2


### PR DESCRIPTION
* Fixes #204. Service worker registration is available at `wp.serviceWorkerWindow` at the `document`'s `DOMContentLoaded` event.
* Discontinue registering the service worker for the admin on the frontend when the user is logged-in. The service worker is installed when the user goes to the login screen already.
* Fixes #444. When `wp_service_worker_skip_waiting` is filtered `false` in PHP, service worker installation waiting can be skipped via `wp.serviceWorkerWindow.messageSkipWaiting()`. See [Workbox docs](https://developers.google.com/web/tools/workbox/modules/workbox-window#skip_waiting_helper).
* Deprecates `wp_disable_script_concatenation()` since admin service worker is not caching admin assets since `WP_Service_Worker_Admin_Assets_Integration` is not enabled by default (and it is deprecated per #403). As part of this the `wordpress_sw_installed` cookie is no longer set when the admin SW is installed.
* Use `module` script instead of `text/javascript` for SW installation on frontend. This incidentally prevents JS errors IE11 which doesn't understand JS modules. Fixes #227.