### PR TITLE
Use `plugins_url()` to allow Workbox script URLs to be filtered

### DIFF
--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -51,8 +51,9 @@ final class WP_Service_Worker_Configuration_Component implements WP_Service_Work
 	 * @return string Script.
 	 */
 	public function get_script() {
-		$current_scope = wp_service_workers()->get_current_scope();
-		$workbox_dir   = sprintf( 'wp-includes/js/workbox-v%s/', PWA_WORKBOX_VERSION );
+		$current_scope    = wp_service_workers()->get_current_scope();
+		$workbox_dir_path = sprintf( 'wp-includes/js/workbox-v%s/', PWA_WORKBOX_VERSION );
+		$workbox_dir_url  = plugins_url( $workbox_dir_path, PWA_PLUGIN_FILE );
 
 		$script = '';
 		if ( SCRIPT_DEBUG ) {
@@ -64,17 +65,17 @@ final class WP_Service_Worker_Configuration_Component implements WP_Service_Work
 			// Load with importScripts() so that source map is available.
 			$script .= sprintf(
 				"importScripts( %s );\n",
-				wp_json_encode( PWA_PLUGIN_URL . $workbox_dir . 'workbox-sw.js' )
+				wp_json_encode( $workbox_dir_url . 'workbox-sw.js' )
 			);
 		} else {
 			// Inline the workbox-sw.js to avoid an additional HTTP request.
-			$wbjs    = file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$wbjs    = file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir_path . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$script .= preg_replace( '://# sourceMappingURL=.+?\.map\s*$:s', '', $wbjs );
 		}
 
 		$options = array(
 			'debug'            => SCRIPT_DEBUG, // When true, the dev builds are loaded. Otherwise, the prod builds are used.
-			'modulePathPrefix' => PWA_PLUGIN_URL . $workbox_dir,
+			'modulePathPrefix' => $workbox_dir_url,
 		);
 		$script .= sprintf( "workbox.setConfig( %s );\n", wp_json_encode( $options ) );
 

--- a/wp-includes/components/class-wp-service-worker-configuration-component.php
+++ b/wp-includes/components/class-wp-service-worker-configuration-component.php
@@ -53,7 +53,7 @@ final class WP_Service_Worker_Configuration_Component implements WP_Service_Work
 	public function get_script() {
 		$current_scope    = wp_service_workers()->get_current_scope();
 		$workbox_dir_path = sprintf( 'wp-includes/js/workbox-v%s/', PWA_WORKBOX_VERSION );
-		$workbox_dir_url  = plugins_url( $workbox_dir_path, PWA_PLUGIN_FILE );
+		$workbox_dir_url  = plugins_url( $workbox_dir_path, PWA_PLUGIN_FILE ); // Core merge: replace with includes_url().
 
 		$script = '';
 		if ( SCRIPT_DEBUG ) {
@@ -69,6 +69,7 @@ final class WP_Service_Worker_Configuration_Component implements WP_Service_Work
 			);
 		} else {
 			// Inline the workbox-sw.js to avoid an additional HTTP request.
+			// Core merge: Replace with PWA_PLUGIN_DIR with ABSPATH . WPINC . etc.
 			$wbjs    = file_get_contents( PWA_PLUGIN_DIR . '/' . $workbox_dir_path . 'workbox-sw.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$script .= preg_replace( '://# sourceMappingURL=.+?\.map\s*$:s', '', $wbjs );
 		}
@@ -123,6 +124,7 @@ final class WP_Service_Worker_Configuration_Component implements WP_Service_Work
 		}
 
 		// Note: This includes the aliasing of `workbox` to `wp.serviceWorker`.
+		// Core merge: Replace with PWA_PLUGIN_DIR with ABSPATH . WPINC . etc.
 		$script .= file_get_contents( PWA_PLUGIN_DIR . '/wp-includes/js/service-worker.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 		return $script;

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -167,11 +167,13 @@ function wp_print_service_workers() {
 		return;
 	}
 
-	$workbox_window_src = sprintf(
-		'%s/wp-includes/js/workbox-v%s/workbox-window.%s.js',
-		PWA_PLUGIN_URL,
-		PWA_WORKBOX_VERSION,
-		SCRIPT_DEBUG ? 'dev' : 'prod'
+	$workbox_window_src = plugins_url(
+		sprintf(
+			'wp-includes/js/workbox-v%s/workbox-window.%s.js',
+			PWA_WORKBOX_VERSION,
+			SCRIPT_DEBUG ? 'dev' : 'prod'
+		),
+		PWA_PLUGIN_FILE
 	);
 	$register_options   = array(
 		'scope' => $scope,

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -167,6 +167,7 @@ function wp_print_service_workers() {
 		return;
 	}
 
+	// Core merge: replace plugins_url() with includes_url().
 	$workbox_window_src = plugins_url(
 		sprintf(
 			'wp-includes/js/workbox-v%s/workbox-window.%s.js',


### PR DESCRIPTION
Fixes #543.

Let's say you have all of the PWA plugin's files located at a CDN with the URL `https://pwa-wp-cdn.example.com/`. You could achieve that with the following plugin code:

```php
if ( defined( 'PWA_PLUGIN_FILE' ) ) {
	add_filter(
		'plugins_url',
		static function ( $url, $path, $plugin ) {
			if ( PWA_PLUGIN_FILE === $plugin ) {
				$url = "https://pwa-wp-cdn.example.com/{$path}";
			}
			return $url;
		},
		10,
		3
	);
}
```