### PR TITLE
Add short name field in General Settings when Site Title is longer than 12 characters

### DIFF
--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -162,6 +162,35 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	}
 
 	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function get_data_to_test_is_name_short() {
+		return array(
+			array( '0123456789ab', true ),
+			array( 'áâàéêèíîìóôò', true ),
+			array( ' áâàéêèíîìóôò ', true ),
+			array( ' 0123456789ab ', true ),
+			array( '0123456789abc', false ),
+			array( 'áâàéêèíîìóôò2', false ),
+		);
+	}
+
+	/**
+	 * Test is_name_short.
+	 *
+	 * @dataProvider get_data_to_test_is_name_short
+	 * @covers ::is_name_short()
+	 *
+	 * @param string $name     Short name to test.
+	 * @param bool   $is_short Whether short is expected.
+	 */
+	public function test_is_name_short( $name, $is_short ) {
+		$this->assertSame( $is_short, $this->instance->is_name_short( $name ) );
+	}
+
+	/**
 	 * Test get_manifest.
 	 *
 	 * @covers ::get_manifest()

--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -360,6 +360,60 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	}
 
 	/**
+	 * Test sort_icons_callback.
+	 *
+	 * @covers ::sort_icons_callback()
+	 */
+	public function test_sort_icons_callback() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test get_url.
+	 *
+	 * @covers ::get_url()
+	 */
+	public function test_get_url() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test register_short_name_setting.
+	 *
+	 * @covers ::register_short_name_setting()
+	 */
+	public function test_register_short_name_setting() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test add_short_name_settings_field.
+	 *
+	 * @covers ::add_short_name_settings_field()
+	 */
+	public function test_add_short_name_settings_field() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test sanitize_short_name.
+	 *
+	 * @covers ::sanitize_short_name()
+	 */
+	public function test_sanitize_short_name() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Test render_short_name_settings_field.
+	 *
+	 * @covers ::render_short_name_settings_field()
+	 */
+	public function test_render_short_name_settings_field() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Gets a mock background color.
 	 *
 	 * @return string $background_color A mock background color.

--- a/tests/test-class-wp-web-app-manifest.php
+++ b/tests/test-class-wp-web-app-manifest.php
@@ -9,6 +9,8 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * Tests for class WP_Web_App_Manifest.
+ *
+ * @coversDefaultClass WP_Web_App_Manifest
  */
 class Test_WP_Web_App_Manifest extends TestCase {
 
@@ -84,7 +86,7 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	/**
 	 * Test init.
 	 *
-	 * @covers WP_Web_App_Manifest::init()
+	 * @covers ::init()
 	 */
 	public function test_init() {
 		$this->instance->init();
@@ -96,7 +98,7 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	/**
 	 * Test manifest_link_and_meta.
 	 *
-	 * @covers WP_Web_App_Manifest::manifest_link_and_meta()
+	 * @covers ::manifest_link_and_meta()
 	 */
 	public function test_manifest_link_and_meta() {
 		$this->mock_site_icon();
@@ -146,7 +148,7 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	/**
 	 * Test get_theme_color.
 	 *
-	 * @covers WP_Web_App_Manifest::get_theme_color()
+	 * @covers ::get_theme_color()
 	 */
 	public function test_get_theme_color() {
 		$test_background_color = '2a7230';
@@ -162,7 +164,7 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	/**
 	 * Test get_manifest.
 	 *
-	 * @covers WP_Web_App_Manifest::get_manifest()
+	 * @covers ::get_manifest()
 	 */
 	public function test_get_manifest() {
 		$this->mock_site_icon();
@@ -202,7 +204,7 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	/**
 	 * Test register_manifest_rest_route.
 	 *
-	 * @covers WP_Web_App_Manifest::register_manifest_rest_route()
+	 * @covers ::register_manifest_rest_route()
 	 */
 	public function test_register_manifest_rest_route() {
 		add_action( 'rest_api_init', array( $this->instance, 'register_manifest_rest_route' ) );
@@ -239,7 +241,7 @@ class Test_WP_Web_App_Manifest extends TestCase {
 	/**
 	 * Test get_icons.
 	 *
-	 * @covers WP_Web_App_Manifest::get_icons()
+	 * @covers ::get_icons()
 	 */
 	public function test_get_icons() {
 

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -499,7 +499,7 @@ final class WP_Web_App_Manifest {
 						id="<?php echo esc_attr( self::SHORT_NAME_OPTION ); ?>"
 						name="<?php echo esc_attr( self::SHORT_NAME_OPTION ); ?>"
 						value="<?php echo esc_attr( $readonly ? $actual_short_name : $short_name_option ); ?>"
-						class="regular-text <?php echo $readonly ? 'disabled' : ''; ?>" maxlength="<?php echo esc_attr( self::SHORT_NAME_MAX_LENGTH ); ?>"
+						class="regular-text <?php echo $readonly ? 'disabled' : ''; ?>" maxlength="<?php echo esc_attr( (string) self::SHORT_NAME_MAX_LENGTH ); ?>"
 						<?php disabled( $readonly ); ?>
 					>
 					<p class="description">

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -203,9 +203,12 @@ final class WP_Web_App_Manifest {
 			'dir'       => is_rtl() ? 'rtl' : 'ltr',
 		);
 
-		// Lighthouse complains when the short_name is absent, even when the name is 12 characters or less. If the name
-		// is 12 characters or less, use it as the short_name.
-		if ( $this->is_name_short( $manifest['name'] ) ) {
+		$short_name = get_option( self::SHORT_NAME_OPTION, '' );
+		if ( $short_name ) {
+			$manifest['short_name'] = $short_name;
+		} elseif ( $this->is_name_short( $manifest['name'] ) ) {
+			// Lighthouse complains when the short_name is absent, even when the name is 12 characters or less. If the name
+			// is 12 characters or less, use it as the short_name.
 			$manifest['short_name'] = trim( $manifest['name'] );
 		}
 
@@ -276,10 +279,9 @@ final class WP_Web_App_Manifest {
 		);
 
 		$actions = sprintf(
-			/* translators: %1$s is `web_app_manifest`, %2$s is `functions.php` */
-			__( 'You currently may use %1$s filter to set the short name, for example in your theme&#8217;s %2$s.', 'pwa' ),
-			'<code>web_app_manifest</code>',
-			'<code>functions.php</code>'
+			/* translators: %s is the URL to the Short Name field on the General Settings screen */
+			__( 'You can update this via the <a href="%s">Short Name field</a> on the General Settings screen.', 'pwa' ),
+			esc_url( admin_url( 'options-general.php' ) . '#short_name' )
 		);
 
 		if ( empty( $manifest['short_name'] ) ) {
@@ -297,7 +299,7 @@ final class WP_Web_App_Manifest {
 			$result = array(
 				'label'       =>
 					sprintf(
-						/* translators: %1$s is the short name */
+						/* translators: %s is the short name */
 						__( 'Web App Manifest has a short name (%s) that is too long', 'pwa' ),
 						esc_html( $manifest['short_name'] )
 					),
@@ -313,7 +315,7 @@ final class WP_Web_App_Manifest {
 			$result = array(
 				'label'       =>
 					sprintf(
-						/* translators: %1$s is the short name */
+						/* translators: %s is the short name */
 						__( 'Web App Manifest has a short name (%s)', 'pwa' ),
 						esc_html( $manifest['short_name'] )
 					),

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -272,10 +272,9 @@ final class WP_Web_App_Manifest {
 		$manifest = $this->get_manifest();
 
 		$description = sprintf(
-			/* translators: %1$s is `short_name`, %2$d is the max length as a number */
-			__( 'The %1$s is a short version of your website&#8217;s name. It is displayed when there is not enough space for the full name, for example with the site icon on a phone&#8217;s homescreen. It should be a maximum of %2$d characters long.', 'pwa' ),
-			'<code>short_name</code>',
-			self::SHORT_NAME_MAX_LENGTH
+			/* translators: %s is the max length as a number */
+			__( 'This is the short version of your site title. It is displayed when there is not enough space for the full title, for example with the site icon on a phone&#8217;s homescreen as an installed app. It should be a maximum of %s characters long.', 'pwa' ),
+			number_format_i18n( self::SHORT_NAME_MAX_LENGTH )
 		);
 
 		$actions = sprintf(
@@ -298,10 +297,12 @@ final class WP_Web_App_Manifest {
 		} elseif ( ! $this->is_name_short( $manifest['short_name'] ) ) {
 			$result = array(
 				'label'       =>
-					sprintf(
-						/* translators: %s is the short name */
-						__( 'Web App Manifest has a short name (%s) that is too long', 'pwa' ),
-						esc_html( $manifest['short_name'] )
+					wp_kses_post(
+						sprintf(
+							/* translators: %s is the short name */
+							__( 'Web App Manifest has a short name (%s) that is too long', 'pwa' ),
+							$manifest['short_name']
+						)
 					),
 				'status'      => 'recommended',
 				'badge'       => array(
@@ -314,10 +315,12 @@ final class WP_Web_App_Manifest {
 		} else {
 			$result = array(
 				'label'       =>
-					sprintf(
-						/* translators: %s is the short name */
-						__( 'Web App Manifest has a short name (%s)', 'pwa' ),
-						esc_html( $manifest['short_name'] )
+					wp_kses_post(
+						sprintf(
+							/* translators: %s is the short name */
+							__( 'Web App Manifest has a short name (%s)', 'pwa' ),
+							$manifest['short_name']
+						)
 					),
 				'status'      => 'good',
 				'badge'       => array(
@@ -508,9 +511,9 @@ final class WP_Web_App_Manifest {
 						<?php
 						echo wp_kses_post(
 							sprintf(
-								/* translators: %1$d is the max length as a number */
-								__( 'This is the short version of your site title. It is displayed when there is not enough space for the full title, for example with the site icon on a phone&#8217;s homescreen as an installed app. It should be a maximum of %1$d characters long.', 'pwa' ),
-								self::SHORT_NAME_MAX_LENGTH
+								/* translators: %s is the max length as a number */
+								__( 'This is the short version of your site title. It is displayed when there is not enough space for the full title, for example with the site icon on a phone&#8217;s homescreen as an installed app. It should be a maximum of %s characters long.', 'pwa' ),
+								number_format_i18n( self::SHORT_NAME_MAX_LENGTH )
 							)
 						);
 						?>

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -281,7 +281,7 @@ final class WP_Web_App_Manifest {
 
 		$actions = sprintf(
 			/* translators: %s is the URL to the Short Name field on the General Settings screen */
-			__( 'You can update this via the <a href="%s">Short Name field</a> on the General Settings screen.', 'pwa' ),
+			__( 'You can update the <a href="%s">Short Name</a> on the General Settings screen.', 'pwa' ),
 			esc_url( admin_url( 'options-general.php' ) . '#short_name' )
 		);
 

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -539,8 +539,7 @@ final class WP_Web_App_Manifest {
 				 * Enable form validation for General Settings. Disabling form validation was done 8 years ago (2014) in
 				 * WP 4.0 in 2014 due to an email validation bug in Firefox. This has since surely been resolved, so
 				 * there is no no need to retain it and we can start to benefit from client-side validation, such as
-				 * the required constraint for the short name. See
-				 * <https://github.com/WordPress/wordpress-develop/commit/0a4e8b2b7ee84efb28acc946a9a54cdd03414c28>
+				 * the required constraint for the short name. See <https://core.trac.wordpress.org/ticket/22183#comment:6>.
 				 */
 				shortNameField.form.noValidate = false;
 

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -184,7 +184,7 @@ final class WP_Web_App_Manifest {
 	 * @param string $name Name.
 	 * @return bool Whether name is short.
 	 */
-	private function is_name_short( $name ) {
+	public function is_name_short( $name ) {
 		$name   = trim( $name );
 		$length = function_exists( 'mb_strlen' ) ? mb_strlen( $name ) : strlen( $name );
 		return $length <= self::SHORT_NAME_MAX_LENGTH;

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -478,6 +478,8 @@ final class WP_Web_App_Manifest {
 
 		// Disable the field if the user is supplying the short name via the web_app_manifest filter.
 		$readonly = (
+			isset( $manifest['short_name'] )
+			&&
 			$actual_short_name !== $short_name_option
 			&&
 			has_filter( 'web_app_manifest' )

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -176,6 +176,7 @@ final class WP_Web_App_Manifest {
 	 * @return bool Whether name is short.
 	 */
 	private function is_name_short( $name ) {
+		$name   = trim( $name );
 		$length = function_exists( 'mb_strlen' ) ? mb_strlen( $name ) : strlen( $name );
 		return $length <= self::SHORT_NAME_MAX_LENGTH;
 	}
@@ -196,7 +197,7 @@ final class WP_Web_App_Manifest {
 		// Lighthouse complains when the short_name is absent, even when the name is 12 characters or less. If the name
 		// is 12 characters or less, use it as the short_name.
 		if ( $this->is_name_short( $manifest['name'] ) ) {
-			$manifest['short_name'] = $manifest['name'];
+			$manifest['short_name'] = trim( $manifest['name'] );
 		}
 
 		$language = get_bloginfo( 'language' );


### PR DESCRIPTION
Fixes #210.

This adds a new Short Name field to the General Settings screen:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/134745/153077744-f3aff1ea-b249-4d10-b51c-2006f4614794.png">

This field is required if the Site Title is longer than 12 characters:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/134745/153077783-d1c3db0d-9437-44e5-be25-e52ca7c62fb5.png">

If if the Site Title is less than or equal to 12 characters long, then the `placeholder` value is set to match the Site Title (since it is used by default in the manifest in this case), and the field is not `required`:

<img width="823" alt="image" src="https://user-images.githubusercontent.com/134745/153077923-6008f40f-bb1b-45e3-9b26-583ee7a05f64.png">

If the Site Title is greater than 12 characters in length, a user must supply a Short Name to save the form (and the field has a `maxlength` of 12 supplied, which is enforced by the `sanitize_callback`):

<img width="820" alt="image" src="https://user-images.githubusercontent.com/134745/153078186-e57f47c3-361e-4433-afe5-583510aaffcf.png">

If a site is supplying the Short Name via a plugin, like as follows (which was the only way to do so before now):

```php
add_filter( 'web_app_manifest', static function ( $manifest ) {
	$manifest['short_name'] = 'WP Dev';
	return $manifest;
} );
```

Then the Short Name field is disabled in the same way the Site URL and Home URL fields if they are defined with constants:

<img width="817" alt="image" src="https://user-images.githubusercontent.com/134745/153078582-ef870497-cac7-4a31-9629-adaa11440b2f.png">

The Site Health test for the Short Name now includes a link to the General Settings screen to manage the field:

<img width="815" alt="image" src="https://user-images.githubusercontent.com/134745/153098532-3931626a-c586-4b93-8b85-05963aef777a.png">

Other changes:

* Use `mb_strlen()` for `short_name` check.
* Use `trim()` on a short name before checking the length or adding to the manifest.
* Enable client-side form validation on the General Settings screen. (It was disabled for a bug in an 8-year old version of Firefox, per TRAC-22183.)