### PR TITLE
Only unauthenticate user when `parse_query` is for the main query

### DIFF
--- a/tests/test-general-template.php
+++ b/tests/test-general-template.php
@@ -75,4 +75,24 @@ class Test_General_Template extends TestCase {
 			$this->assertEquals( 0, get_current_user_id() );
 		}
 	}
+
+	/**
+	 * Test that that `wp_unauthenticate_error_template_requests()` running at the `parse_query` action doesn't cause
+	 * an incorrect usage notice if there is not global `$wp_query` yet, such as when doing a subquery early in the WP
+	 * execution flow.
+	 *
+	 * @covers ::wp_unauthenticate_error_template_requests()
+	 */
+	public function test_wp_unauthenticate_error_template_requests_for_subqueries() {
+		global $wp_query;
+		$wp_query = null;
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $user_id );
+
+		$query = new WP_Query();
+		$query->parse_query( 's=test' );
+
+		$this->assertTrue( is_user_logged_in() );
+	}
 }

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -123,9 +123,11 @@ function wp_add_error_template_no_robots() {
  * will persist even after they have authenticated.
  *
  * @since 0.5
+ *
+ * @param WP_Query $query Query.
  */
-function wp_unauthenticate_error_template_requests() {
-	if ( is_offline() || is_500() ) {
+function wp_unauthenticate_error_template_requests( WP_Query $query ) {
+	if ( $query->is_main_query() && ( is_offline() || is_500() ) ) {
 		wp_set_current_user( 0 );
 	}
 }


### PR DESCRIPTION
This is a follow-up to #279 and it addresses a conflict with Polylang identified in a [support topic](https://wordpress.org/support/topic/conflict-with-polylang-21/).

The issue is that if a `WP_Query` instance is created before the main query, then this can result in our `wp_unauthenticate_error_template_requests()` running on the `parse_query`  action when there is no `$wp_query` global yet set. The result is a notice:

> PHP Notice:  is_offline was called <strong>incorrectly</strong>. Conditional query tags do not work before the query is run. Before then, they always return false. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.1.0.) in /app/public/core-dev/src/wp-includes/functions.php on line 5768

The fix is simply to ensure that the query being parsed is the main query, because that will ensure that the `$wp_the_query` has been set, at which point the `$wp_query` global has already been set.

Fixes #538.