### PR TITLE
Remove novalidate attribute from comment form to enable client-side validation

### DIFF
--- a/pwa.php
+++ b/pwa.php
@@ -299,7 +299,7 @@ add_action( 'wp_default_service_workers', 'pwa_load_service_worker_integrations'
 function pwa_remove_novalidate_attribute_from_comments_form() {
 	?>
 	<script type="module">
-		var commentForm = document.getElementById( 'commentform' );
+		const commentForm = document.getElementById( 'commentform' );
 		if ( commentForm ) {
 			commentForm.removeAttribute( 'novalidate' );
 		}

--- a/pwa.php
+++ b/pwa.php
@@ -290,6 +290,24 @@ function pwa_load_service_worker_integrations( WP_Service_Worker_Scripts $script
 }
 add_action( 'wp_default_service_workers', 'pwa_load_service_worker_integrations', -1 );
 
+/**
+ * Remove `novalidate` attribute from the comment form tag.
+ *
+ * This is a fix for the `novalidate` attribute being added to the comment form by WordPress
+ * which disables HTML client-side validation for the form.
+ */
+function pwa_remove_novalidate_attribute_from_comments_form() {
+	?>
+	<script type="module">
+		var commentForm = document.getElementById( 'commentform' );
+		if ( commentForm ) {
+			commentForm.removeAttribute( 'novalidate' );
+		}
+	</script>
+	<?php
+}
+add_action( 'comment_form_after', 'pwa_remove_novalidate_attribute_from_comments_form', 10, 0 );
+
 $wp_web_app_manifest = new WP_Web_App_Manifest();
 $wp_web_app_manifest->init();
 


### PR DESCRIPTION
Fixes: #364 
This PR adds an action to remove the `novalidate` attribute which is added by WordPress core in the comments form. Removing that attribute will enable client-side validation too for comment form which may not allow invalid data to be submitted.

## Screenshot
![image](https://user-images.githubusercontent.com/53530700/156118822-263fcd2d-d1fe-435d-9a80-e7a13b642846.png)
