### PR TITLE
Conditionally installing service workers on registered scripts or offline browsing enabled.

### DIFF
--- a/tests/test-service-workers.php
+++ b/tests/test-service-workers.php
@@ -114,4 +114,50 @@ class Test_Service_Workers_Includes extends TestCase {
 			wp_get_service_worker_url( WP_Service_Workers::SCOPE_ADMIN )
 		);
 	}
+
+	/**
+	 * Test wp_get_actions_with_registered_service_worker_scripts() when no scripts are added.
+	 *
+	 * @covers ::wp_get_actions_with_registered_service_worker_scripts()
+	 */
+	public function test_wp_get_actions_with_registered_service_worker_scripts_with_no_scripts() {
+
+		remove_all_actions( 'wp_front_service_worker' );
+		remove_all_actions( 'wp_admin_service_worker' );
+
+		$this->assertEquals(
+			array(),
+			wp_get_actions_with_registered_service_worker_scripts()
+		);
+	}
+
+	/**
+	 * Test wp_get_actions_with_registered_service_worker_scripts() when scripts are added.
+	 *
+	 * @covers ::wp_get_actions_with_registered_service_worker_scripts()
+	 */
+	public function test_wp_get_actions_with_registered_service_worker_scripts_with_registered_scripts() {
+		// Register for the admin service worker.
+		add_action( 'wp_front_service_worker', 'register_foo_sw' );
+
+		$this->assertEquals(
+			array( 'wp_front_service_worker' ),
+			wp_get_actions_with_registered_service_worker_scripts()
+		);
+	}
+
+	/**
+	 * Register a service worker.
+	 *
+	 * @param WP_Service_Worker_Scripts $scripts Registry instance.
+	 */
+	public function register_foo_sw( $scripts ) {
+		$scripts->register(
+			'foo',
+			array(
+				'src'  => array( $this, 'return_foo_sw' ),
+				'deps' => array(),
+			)
+		);
+	}
 }

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -9,53 +9,51 @@
 
 $service_worker_actions = wp_get_actions_with_registered_service_worker_scripts();
 
-if ( get_option( 'offline_browsing' ) || ! empty( $service_worker_actions ) ) {
+// Array of filter hooks that are used to trigger the service worker.
+$hooks = array(
+	'front' => array(
+		'wp_print_footer_scripts',
+	),
+	'admin' => array(
+		'admin_print_scripts',
+		'customize_controls_print_scripts',
+		'login_footer',
+		'after_signup_form',
+		'activate_wp_head',
+	),
+);
 
+if ( get_option( 'offline_browsing' ) ) {
 	// Ensure service workers are printed on frontend, admin, Customizer, login, sign-up, and activate pages.
-	$hooks = array(
-		'front' => array(
-			'wp_print_footer_scripts',
-		),
-		'admin' => array(
-			'admin_print_scripts',
-			'customize_controls_print_scripts',
-			'login_footer',
-			'after_signup_form',
-			'activate_wp_head',
-		),
-	);
-
-	if ( get_option( 'offline_browsing' ) ) {
-		// Ensure service workers are printed on frontend, admin, Customizer, login, sign-up, and activate pages.
-		foreach ( array_merge( $hooks['front'], $hooks['admin'] ) as $filter ) {
-			add_filter( $filter, 'wp_print_service_workers', 9 );
-		}
-
-		add_action( 'parse_query', 'wp_service_worker_loaded' );
-		add_action( 'wp_ajax_wp_service_worker', 'wp_ajax_wp_service_worker' );
-		add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
-		add_action( 'parse_query', 'wp_unauthenticate_error_template_requests' );
+	foreach ( array_merge( $hooks['front'], $hooks['admin'] ) as $filter ) {
+		add_filter( $filter, 'wp_print_service_workers', 9 );
 	}
 
-	if ( in_array( 'wp_front_service_worker', $service_worker_actions ) ) {
-		// Ensure service workers are printed on frontend.
-		add_filter( 'wp_print_footer_scripts', 'wp_print_service_workers', 9 );
-
-		add_action( 'parse_query', 'wp_service_worker_loaded' );
-		add_action( 'parse_query', 'wp_unauthenticate_error_template_requests' );
-	}
-
-	if ( in_array( 'wp_admin_service_worker', $service_worker_actions ) ) {
+	add_action( 'parse_query', 'wp_service_worker_loaded' );
+	add_action( 'wp_ajax_wp_service_worker', 'wp_ajax_wp_service_worker' );
+	add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
+} else if ( ! empty( $service_worker_actions ) ) {
+	if ( in_array( 'wp_front_service_worker', $service_worker_actions, true ) ) {
 		// Ensure service workers are printed on admin, Customizer, login, sign-up, and activate pages.
-		foreach ( array( 'admin_print_scripts', 'customize_controls_print_scripts', 'login_footer', 'after_signup_form', 'activate_wp_head' ) as $filter ) {
+		foreach ( $hooks['front'] as $filter ) {
+			add_filter( $filter, 'wp_print_service_workers', 9 );
+		}
+
+		add_action( 'parse_query', 'wp_service_worker_loaded' );
+	}
+
+	if ( in_array( 'wp_admin_service_worker', $service_worker_actions, true ) ) {
+		// Ensure service workers are printed on admin, Customizer, login, sign-up, and activate pages.
+		foreach ( $hooks['admin'] as $filter ) {
 			add_filter( $filter, 'wp_print_service_workers', 9 );
 		}
 
 		add_action( 'wp_ajax_wp_service_worker', 'wp_ajax_wp_service_worker' );
 		add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
-		add_action( 'parse_query', 'wp_unauthenticate_error_template_requests' );
 	}
 }
+
+add_action( 'parse_query', 'wp_unauthenticate_error_template_requests' );
 
 if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.7', '>=' ) ) {
 	add_action( 'error_head', 'wp_robots', 1 ); // To match wp_robots running at wp_head.

--- a/wp-includes/default-filters.php
+++ b/wp-includes/default-filters.php
@@ -34,7 +34,7 @@ if ( get_option( 'offline_browsing' ) ) {
 	add_action( 'wp_ajax_nopriv_wp_service_worker', 'wp_ajax_wp_service_worker' );
 } else if ( ! empty( $service_worker_actions ) ) {
 	if ( in_array( 'wp_front_service_worker', $service_worker_actions, true ) ) {
-		// Ensure service workers are printed on admin, Customizer, login, sign-up, and activate pages.
+		// Ensure service workers are printed on frontend.
 		foreach ( $hooks['front'] as $filter ) {
 			add_filter( $filter, 'wp_print_service_workers', 9 );
 		}

--- a/wp-includes/service-workers.php
+++ b/wp-includes/service-workers.php
@@ -258,3 +258,17 @@ function wp_service_worker_skip_waiting() {
 	 */
 	return (bool) apply_filters( 'wp_service_worker_skip_waiting', true );
 }
+
+/**
+ * Function to check if service worker scripts are registered on
+ * `wp_front_service_worker` or `wp_admin_service_worker` action hooks.
+ *
+ * @return array Array of hooks to which the actions are registered.
+ */
+function wp_get_actions_with_registered_service_worker_scripts() {
+	$actions = array();
+	has_action( 'wp_front_service_worker' ) ? $actions[] = 'wp_front_service_worker' : null;
+	has_action( 'wp_admin_service_worker' ) ? $actions[] = 'wp_admin_service_worker' : null;
+
+	return $actions;
+}


### PR DESCRIPTION
Fixes: #436 

This PR conditionally installs the service worker when there are Service Worker scripts coming from other plugins or if the `offline browsing` option of the PWA plugin is enabled.
 
 ## Implementation 
https://user-images.githubusercontent.com/53530700/157613069-c135c0b9-70fb-40f7-9386-540e8b249bab.mp4