### PR TITLE
Prevent auto-reloading on error pages in response to POST requests

### DIFF
--- a/tests/test-template.php
+++ b/tests/test-template.php
@@ -11,6 +11,7 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  * Tests for template.php
  */
 class Test_Template extends TestCase {
+
 	/**
 	 * Test if function adding script on GET method, is_offline() or is_500 is true
 	 *
@@ -21,8 +22,7 @@ class Test_Template extends TestCase {
 		$this->assertEquals( 10, has_action( 'error_footer', 'wp_service_worker_offline_page_reload' ) );
 
 		// Check when method is GET but not offline or 500.
-		$actual_script = wp_service_worker_offline_page_reload();
-		$this->assertEquals( $_SERVER['REQUEST_METHOD'], 'GET' );
+		$actual_script = get_echo( 'wp_service_worker_offline_page_reload' );
 		$this->assertFalse( is_offline() );
 		$this->assertFalse( is_500() );
 		$this->assertEmpty( $actual_script );
@@ -31,36 +31,20 @@ class Test_Template extends TestCase {
 		$error_template_url = add_query_arg( 'wp_error_template', 'offline', home_url( '/', 'relative' ) );
 		$this->go_to( $error_template_url );
 
-		ob_start();
-		wp_service_worker_offline_page_reload();
-		$actual_script = ob_get_clean();
-		$this->assertEquals( $_SERVER['REQUEST_METHOD'], 'GET' );
+		$actual_script = get_echo( 'wp_service_worker_offline_page_reload' );
 		$this->assertTrue( is_offline() );
 		$this->assertFalse( is_500() );
 		$this->assertStringContainsString( '<script type="module">', $actual_script );
-		$this->assertStringContainsString( 'await fetch(location.href, {method: \'HEAD\'})', $actual_script );
+		$this->assertStringContainsString( 'await fetch', $actual_script );
 
 		// Check if script is added when 500.
 		$error_template_url = add_query_arg( 'wp_error_template', '500', home_url( '/', 'relative' ) );
 		$this->go_to( $error_template_url );
 
-		ob_start();
-		wp_service_worker_offline_page_reload();
-		$actual_script = ob_get_clean();
-		$this->assertEquals( $_SERVER['REQUEST_METHOD'], 'GET' );
+		$actual_script = get_echo( 'wp_service_worker_offline_page_reload' );
 		$this->assertFalse( is_offline() );
 		$this->assertTrue( is_500() );
 		$this->assertStringContainsString( '<script type="module">', $actual_script );
-		$this->assertStringContainsString( 'await fetch(location.href, {method: \'HEAD\'})', $actual_script );
-
-		$this->go_to( home_url( '/', 'relative' ) );
-
-		// Check when method is not GET.
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$actual_script             = wp_service_worker_offline_page_reload();
-		$this->assertEquals( $_SERVER['REQUEST_METHOD'], 'POST' );
-		$this->assertFalse( is_offline() );
-		$this->assertFalse( is_500() );
-		$this->assertEmpty( $actual_script );
+		$this->assertStringContainsString( 'await fetch', $actual_script );
 	}
 }

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -183,12 +183,32 @@ function wp_service_worker_offline_page_reload() {
 	}
 
 	?>
+	<script id="wp-navigation-request-properties" type="application/json">{{{WP_NAVIGATION_REQUEST_PROPERTIES}}}</script><?php // phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
 	<script type="module">
-		if (!new URLSearchParams(location.search.substr(1)).has("wp_error_template")) {
+		const shouldRetry = () => {
+			if (
+				new URLSearchParams(location.search.substring(1)).has(
+					'wp_error_template'
+				)
+			) {
+				return false;
+			}
+
+			const navigationRequestProperties = JSON.parse(
+				document.getElementById('wp-navigation-request-properties').text
+			);
+			if ('GET' !== navigationRequestProperties.method) {
+				return false;
+			}
+
+			return true;
+		};
+
+		if (shouldRetry()) {
 			/**
-			* Listen to changes in the network state, reload when online.
-			* This handles the case when the device is completely offline.
-			*/
+			 * Listen to changes in the network state, reload when online.
+			 * This handles the case when the device is completely offline.
+			 */
 			window.addEventListener('online', () => {
 				window.location.reload();
 			});
@@ -197,12 +217,14 @@ function wp_service_worker_offline_page_reload() {
 			let count = 0;
 
 			/**
-			* Check if the server is responding and reload the page if it is.
-			* This handles the case when the device is online, but the server is offline or misbehaving.
-			*/
+			 * Check if the server is responding and reload the page if it is.
+			 * This handles the case when the device is online, but the server is offline or misbehaving.
+			 */
 			async function checkNetworkAndReload() {
 				try {
-					const response = await fetch(location.href, {method: 'HEAD'});
+					const response = await fetch(location.href, {
+						method: 'HEAD',
+					});
 					// Verify we get a valid response from the server
 					if (response.status >= 200 && response.status < 500) {
 						window.location.reload();
@@ -211,8 +233,12 @@ function wp_service_worker_offline_page_reload() {
 				} catch {
 					// Unable to connect so do nothing.
 				}
-				window.setTimeout(checkNetworkAndReload, Math.pow(2, count++) * 2500);
+				window.setTimeout(
+					checkNetworkAndReload,
+					Math.pow(2, count++) * 2500
+				);
 			}
+
 			checkNetworkAndReload();
 		}
 	</script>

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -178,10 +178,6 @@ function wp_service_worker_error_message_placeholder() {
  * @since 0.7
  */
 function wp_service_worker_offline_page_reload() {
-	if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
-		return;
-	}
-
 	if ( ! is_offline() && ! is_500() ) {
 		return;
 	}


### PR DESCRIPTION
Originally in https://github.com/GoogleChromeLabs/pwa-wp/pull/697#discussion_r850892778:

> As part of #728, I just realized that this check will never do anything:
> 
> https://github.com/GoogleChromeLabs/pwa-wp/blob/124baabe30f70b718960fa18158f10a54943287e/wp-includes/template.php#L181-L184
> 
> This is because the offline template is always fetched via a `GET` request by the service worker when it is installing, so it will never not be `GET`. We need an alternative way of preventing the code from running on responses to non-GET requests.
> 
> Contrary to what I thought above, each reload does _not_ cause the browser re-POST message: [#728 (comment)](https://github.com/GoogleChromeLabs/pwa-wp/pull/728#issuecomment-1099718487)

We need to prevent this from happening:

https://user-images.githubusercontent.com/134745/163492942-9f50a441-cc84-4854-92fa-79a0a34d95d8.mov

We need to export the request method from the service worker fetch handler to the JS in the `wp_service_worker_offline_page_reload()` so that it can decide whether or not to try reloading.