### PR TITLE
Fix maskable icon setting behaviour based on site icon

### DIFF
--- a/wp-admin/js/customize-controls-site-icon-pwa.js
+++ b/wp-admin/js/customize-controls-site-icon-pwa.js
@@ -18,6 +18,9 @@ wp.customize(
 					);
 				};
 
+				// Force the value to always correspond to whether the site icon is present, disregarding server control.
+				siteIconMaskableControl.active.validate = hasSiteIcon;
+
 				/**
 				 * Toggle site icon maskable active state based on whether the site icon is set.
 				 */

--- a/wp-admin/js/customize-controls-site-icon-pwa.js
+++ b/wp-admin/js/customize-controls-site-icon-pwa.js
@@ -18,9 +18,6 @@ wp.customize(
 					);
 				};
 
-				// Force the value to always correspond to whether the site icon is present, disregarding server control.
-				siteIconMaskableControl.active.validate = hasSiteIcon;
-
 				/**
 				 * Toggle site icon maskable active state based on whether the site icon is set.
 				 */

--- a/wp-admin/js/customize-controls-site-icon-pwa.js
+++ b/wp-admin/js/customize-controls-site-icon-pwa.js
@@ -31,6 +31,13 @@ wp.customize(
 				// Update active state whenever the site_icon setting changes.
 				siteIconSetting.bind(updateActive);
 
+				// Change the site_icon_maskable if site_icon is not set.
+				siteIconSetting.bind((newSiteIconValue) => {
+					if (!newSiteIconValue) {
+						siteIconMaskableSetting(false);
+					}
+				});
+
 				/**
 				 * Validate site icons for its presence and size.
 				 */

--- a/wp-includes/class-wp-customize-manager.php
+++ b/wp-includes/class-wp-customize-manager.php
@@ -35,13 +35,10 @@ function pwa_customize_register_site_icon_maskable( WP_Customize_Manager $wp_cus
 		$wp_customize->add_control(
 			'site_icon_maskable',
 			array(
-				'type'            => 'checkbox',
-				'section'         => 'title_tagline',
-				'label'           => __( 'Maskable icon', 'pwa' ),
-				'priority'        => $site_icon_control->priority + 1,
-				'active_callback' => function() use ( $wp_customize ) {
-					return (bool) $wp_customize->get_setting( 'site_icon' )->value();
-				},
+				'type'     => 'checkbox',
+				'section'  => 'title_tagline',
+				'label'    => __( 'Maskable icon', 'pwa' ),
+				'priority' => $site_icon_control->priority + 1,
 			)
 		);
 	}

--- a/wp-includes/class-wp-customize-manager.php
+++ b/wp-includes/class-wp-customize-manager.php
@@ -35,10 +35,13 @@ function pwa_customize_register_site_icon_maskable( WP_Customize_Manager $wp_cus
 		$wp_customize->add_control(
 			'site_icon_maskable',
 			array(
-				'type'     => 'checkbox',
-				'section'  => 'title_tagline',
-				'label'    => __( 'Maskable icon', 'pwa' ),
-				'priority' => $site_icon_control->priority + 1,
+				'type'            => 'checkbox',
+				'section'         => 'title_tagline',
+				'label'           => __( 'Maskable icon', 'pwa' ),
+				'priority'        => $site_icon_control->priority + 1,
+				'active_callback' => function() use ( $wp_customize ) {
+					return (bool) $wp_customize->get_setting( 'site_icon' )->value();
+				},
 			)
 		);
 	}

--- a/wp-includes/class-wp-web-app-manifest.php
+++ b/wp-includes/class-wp-web-app-manifest.php
@@ -504,16 +504,18 @@ final class WP_Web_App_Manifest {
 			$src = get_site_icon_url( $size );
 			if ( $src ) {
 				$icon = array(
-					'src'   => $src,
-					'sizes' => sprintf( '%1$dx%1$d', $size ),
-					'type'  => $mime_type,
+					'purpose' => 'any',
+					'src'     => $src,
+					'sizes'   => sprintf( '%1$dx%1$d', $size ),
+					'type'    => $mime_type,
 				);
 
-				if ( $maskable ) {
-					$icon['purpose'] = 'any maskable';
-				}
-
 				$icons[] = $icon;
+
+				if ( $maskable ) {
+					$icon['purpose'] = 'maskable';
+					$icons[]         = $icon;
+				}
 			}
 		}
 		return $icons;


### PR DESCRIPTION
This is a follow-up to #304 and was originally discussed in https://github.com/GoogleChromeLabs/pwa-wp/issues/304#issuecomment-1102984440. 

This PR aims to:

- Add logic to hide the `Maskable Icon` checkbox if site icon is not set.
- Add logic to remove `checked` from  `Maskable Icon` checkbox if the user has removed the site icon. 