### PR TITLE
Rename sourcemap files when renaming .mjs to .js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,7 @@ module.exports = function (grunt) {
 					'for mjs in wp-includes/js/workbox*/*.mjs; do ' +
 					'sed "s/\\.mjs/.js/g" "$mjs" > "${mjs%mjs}js";' +
 					'rm $mjs;' +
+					'if [ -e $mjs.map ]; then mv $mjs.map "${mjs%mjs}js.map"; fi;' +
 					'done;',
 			},
 			create_build_zip: {


### PR DESCRIPTION
This follows up on something I missed in 46aa70a097d3065854c78e20365fb1de3820d2c5 (as part of #578). Namely, I saw in the console:

> DevTools failed to load source map: Could not load content for .../pwa/wp-includes/js/workbox-v6.5.3/workbox-window.dev.js.map: HTTP error: status code 404, net::ERR_HTTP_RESPONSE_CODE_FAILURE

The issue is that when I renamed `.mjs` to `.js` I didn't also rename the `.mjs.map` to `.js.map`. This results in the following change to the build:

```diff
130c130
< ./wp-includes/js/workbox-v6.5.3/workbox-window.dev.es5.mjs.map
---
> ./wp-includes/js/workbox-v6.5.3/workbox-window.dev.es5.js.map
132c132
< ./wp-includes/js/workbox-v6.5.3/workbox-window.dev.mjs.map
---
> ./wp-includes/js/workbox-v6.5.3/workbox-window.dev.js.map
136c136
< ./wp-includes/js/workbox-v6.5.3/workbox-window.prod.es5.mjs.map
---
> ./wp-includes/js/workbox-v6.5.3/workbox-window.prod.es5.js.map
138c138
< ./wp-includes/js/workbox-v6.5.3/workbox-window.prod.mjs.map
---
> ./wp-includes/js/workbox-v6.5.3/workbox-window.prod.js.map
```