### PR TITLE
Improve performance of denylist patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+indent_size = 4
 
 [{.eslintrc,*.json,*.yml}]
 indent_style = space

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -157,10 +157,7 @@ jobs:
         run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
 
       - name: Normalize composer.json
-        run: |
-          composer require --no-interaction --dev ergebnis/composer-normalize --ignore-platform-reqs
-          composer config --no-interaction --no-plugins allow-plugins.ergebnis/composer-normalize true
-          composer --no-interaction normalize --dry-run
+        run: vendor/bin/composer-normalize --dry-run
 
   #-----------------------------------------------------------------------------------------------------------------------
 

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+	"composer.*": () => "vendor/bin/composer-normalize",
+	"package.json": [
+		"npm run lint:pkg-json"
+	],
+	"**/*.js": [
+		"npm run lint:js"
+	],
+	"**/!(pwa).php": [
+		"npm run lint:php"
+	],
+	"pwa.php": [
+		"vendor/bin/phpcs --runtime-set testVersion 5.2-"
+	]
+};

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
+  "config": {
+    "WP_SERVICE_WORKER_DEBUG_LOG": true
+  },
   "env": {
     "development": {
       "plugins": [

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "wordpress-plugin",
   "homepage": "https://github.com/GoogleChromeLabs/pwa-wp",
   "require": {
-    "ext-json": "*",
-    "php": "^5.6 || ^7.0 || ^8.0"
+    "php": "^5.6 || ^7.0 || ^8.0",
+    "ext-json": "*"
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.3",
@@ -32,6 +32,11 @@
   },
   "extra": {
     "downloads": {
+      "composer-normalize": {
+        "path": "vendor/bin/composer-normalize",
+        "type": "phar",
+        "url": "https://github.com/ergebnis/composer-normalize/releases/latest/download/composer-normalize.phar"
+      },
       "phpstan": {
         "path": "vendor/bin/phpstan",
         "type": "phar",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "type": "wordpress-plugin",
   "homepage": "https://github.com/GoogleChromeLabs/pwa-wp",
   "require": {
+    "ext-json": "*",
     "php": "^5.6 || ^7.0 || ^8.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec401f6b8d639e06d37af7f3963a6078",
+    "content-hash": "01c2762ea195f385cd9e3a84b618890b",
     "packages": [],
     "packages-dev": [
         {
@@ -2840,8 +2840,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "ext-json": "*",
-        "php": "^5.6 || ^7.0 || ^8.0"
+        "php": "^5.6 || ^7.0 || ^8.0",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c64b044621eee1c29d1d1e3fc6490899",
+    "content-hash": "ec401f6b8d639e06d37af7f3963a6078",
     "packages": [],
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.15",
+            "version": "2.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961"
+                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/0430ceaac7f447f1778c199ec19d7e4362a6f961",
-                "reference": "0430ceaac7f447f1778c199ec19d7e4362a6f961",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
+                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
                 "shasum": ""
             },
             "require": {
@@ -51,9 +51,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.15"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.21"
             },
-            "time": "2021-08-22T08:00:13+00:00"
+            "time": "2022-02-07T07:28:34+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -109,27 +109,27 @@
         },
         {
             "name": "brain/monkey",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "7042140000b4b18034c0c0010d86274a00f25442"
+                "reference": "a31c84515bb0d49be9310f52ef1733980ea8ffbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/7042140000b4b18034c0c0010d86274a00f25442",
-                "reference": "7042140000b4b18034c0c0010d86274a00f25442",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/a31c84515bb0d49be9310f52ef1733980ea8ffbb",
+                "reference": "a31c84515bb0d49be9310f52ef1733980ea8ffbb",
                 "shasum": ""
             },
             "require": {
-                "antecedent/patchwork": "^2.0",
-                "mockery/mockery": ">=0.9 <2",
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "^1.3.5 || ^1.4.4",
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
                 "phpcompatibility/php-compatibility": "^9.3.0",
-                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -139,12 +139,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Brain\\Monkey\\": "src/"
-                },
                 "files": [
                     "inc/api.php"
-                ]
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -175,7 +175,7 @@
                 "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
                 "source": "https://github.com/Brain-WP/BrainMonkey"
             },
-            "time": "2020-10-13T17:56:14+00:00"
+            "time": "2021-11-11T15:53:55+00:00"
         },
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -417,16 +417,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "31467aeb3ca3188158613322d66df81cedd86626"
+                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/31467aeb3ca3188158613322d66df81cedd86626",
-                "reference": "31467aeb3ca3188158613322d66df81cedd86626",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/472fa8ca4e55483d55ee1e73c963718c4393791d",
+                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d",
                 "shasum": ""
             },
             "require": {
@@ -480,9 +480,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.3.4"
+                "source": "https://github.com/mockery/mockery/tree/1.3.5"
             },
-            "time": "2021-02-24T09:51:00+00:00"
+            "time": "2021-09-13T15:33:03+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -2071,16 +2071,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.2",
+            "version": "v2.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e"
+                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/c921498b474212fe4552928bbeb68d70250ce5e8",
+                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8",
                 "shasum": ""
             },
             "require": {
@@ -2120,7 +2120,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2021-07-06T23:45:17+00:00"
+            "time": "2022-02-21T17:01:13+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2270,12 +2270,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2708,16 +2708,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
                 "shasum": ""
             },
             "require": {
@@ -2725,9 +2725,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -2767,7 +2765,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-08-09T16:28:08+00:00"
+            "time": "2021-11-23T01:37:03+00:00"
         },
         {
             "name": "yoast/wp-test-utils",
@@ -2842,6 +2840,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
+        "ext-json": "*",
         "php": "^5.6 || ^7.0 || ^8.0"
     },
     "platform-dev": [],

--- a/package.json
+++ b/package.json
@@ -64,20 +64,6 @@
     "env:wp": "wp-env run cli wp",
     "wp-env": "wp-env"
   },
-  "lint-staged": {
-    "package.json": [
-      "npm run lint:pkg-json"
-    ],
-    "**/*.js": [
-      "npm run lint:js"
-    ],
-    "**/!(pwa).php": [
-      "npm run lint:php"
-    ],
-    "pwa.php": [
-      "vendor/bin/phpcs --runtime-set testVersion 5.2-"
-    ]
-  },
   "npmpackagejsonlint": {
     "extends": "@wordpress/npm-package-json-lint-config",
     "rules": {

--- a/tests/components/test-class-wp-service-worker-navigation-routing-component.php
+++ b/tests/components/test-class-wp-service-worker-navigation-routing-component.php
@@ -32,4 +32,134 @@ class Test_WP_Service_Worker_Navigation_Routing_Component extends TestCase {
 		$instance = new WP_Service_Worker_Navigation_Routing_Component();
 		$this->assertSame( 99, $instance->get_priority() );
 	}
+
+	/**
+	 * Get data to test get_navigation_route_denylist_patterns.
+	 *
+	 * @return array
+	 */
+	public function get_data_to_test_get_navigation_route_denylist_patterns() {
+		return array(
+			'many_query_params'           => array(
+				home_url( '/?ab=4&v0=56&u0=degrees+Celsius+%28°C%29&f0=C&v1=60&u1=degrees+Celsius+%28°C%29&f1=C&v2=0.0005&u2=per+degree+Celsius+%28%2F°C%29&f2=CdT&v3=100&u3=centimetres+%28cm%29&f3=cm&u4=centimetres+%28cm%29&f4=cm&v5=100&u5=sq+centimetres+%28cm²%29&f5=sqcm&v6=100.4&u6=sq+centimetres+%28cm²%29&f6=sqcm&v7=100&u7=cu+centimetres+%28cc%2C+cm³%29&f7=cucm&v8=100.6&u8=cu+centimetres+%28cc%2C+cm³%29&f8=cucm' ),
+				false,
+			),
+			'admin_url'                   => array(
+				admin_url(),
+				true,
+			),
+			'admin_url_index'             => array(
+				admin_url( '/index.php' ),
+				true,
+			),
+			'admin_url_slash'             => array(
+				admin_url( '/' ),
+				true,
+			),
+			'login'                       => array(
+				wp_login_url(),
+				true,
+			),
+			'service_worker_front_pretty' => array(
+				home_url( '/wp.serviceworker' ),
+				true,
+			),
+			'service_worker_front_false'  => array(
+				home_url( '/info/?url=/wp.serviceworker' ),
+				false,
+			),
+			'service_worker_front_ugly'   => array(
+				add_query_arg(
+					array( WP_Service_Workers::QUERY_VAR => WP_Service_Workers::SCOPE_ADMIN ),
+					home_url( '/', 'relative' )
+				),
+				true,
+			),
+			'service_worker_admin'        => array(
+				wp_get_service_worker_url( WP_Service_Workers::SCOPE_ADMIN ),
+				true,
+			),
+			'feed_url'                    => array(
+				home_url( '/feed/' ),
+				true,
+			),
+			'feed_rss2_url'               => array(
+				home_url( '/feed/rss2/' ),
+				true,
+			),
+			'customize_preview_1'         => array(
+				home_url( '/?wp_customize=1' ),
+				true,
+			),
+			'customize_preview_2'         => array(
+				home_url( '/?foo=bar&wp_customize=1' ),
+				true,
+			),
+			'customize_preview_4'         => array(
+				home_url( '/?customize_changeset_uuid=...' ),
+				true,
+			),
+			'customize_preview_5'         => array(
+				home_url( '/?foo=bar&customize_changeset_uuid=...' ),
+				true,
+			),
+			'about_page'                  => array(
+				home_url( '/about/' ),
+				false,
+			),
+			'php_file_in_query_param'     => array(
+				home_url( '/inspect/?file=foo.php' ),
+				false,
+			),
+			'rest_api'                    => array(
+				get_rest_url(),
+				true,
+			),
+			'filter'                      => array(
+				home_url( '/denied/' ),
+				true,
+				static function () {
+					add_filter(
+						'wp_service_worker_navigation_route_denylist_patterns',
+						static function ( $patterns ) {
+							$patterns[] = '^.*?\/denied\/';
+							return $patterns;
+						}
+					);
+				},
+			),
+		);
+	}
+
+	/**
+	 * Test get_navigation_route_denylist_patterns.
+	 *
+	 * @covers ::get_navigation_route_denylist_patterns()
+	 * @dataProvider get_data_to_test_get_navigation_route_denylist_patterns
+	 *
+	 * @param string  $url      URL.
+	 * @param bool    $expected Expected match.
+	 * @param Closure $setup    Custom setup.
+	 */
+	public function test_get_navigation_route_denylist_patterns( $url, $expected, $setup = null ) {
+		if ( $setup ) {
+			$setup();
+		}
+
+		$instance  = new WP_Service_Worker_Navigation_Routing_Component();
+		$patterns  = $instance->get_navigation_route_denylist_patterns();
+		$matched   = null;
+		$delimiter = chr( 1 );
+		foreach ( $patterns as $pattern ) {
+			if ( preg_match( $delimiter . $pattern . $delimiter, $url ) ) {
+				$matched = $pattern;
+				break;
+			}
+		}
+		$this->assertSame(
+			$expected,
+			(bool) $matched,
+			wp_json_encode( compact( 'matched', 'url' ), JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+		);
+	}
 }

--- a/tests/components/test-class-wp-service-worker-navigation-routing-component.php
+++ b/tests/components/test-class-wp-service-worker-navigation-routing-component.php
@@ -146,6 +146,13 @@ class Test_WP_Service_Worker_Navigation_Routing_Component extends TestCase {
 			$setup();
 		}
 
+		// Only the path and search are considered by Workbox in navigation requests.
+		$parsed_url = wp_parse_url( $url );
+		$url        = $parsed_url['path'];
+		if ( ! empty( $parsed_url['query'] ) ) {
+			$url .= '?' . $parsed_url['query'];
+		}
+
 		$instance  = new WP_Service_Worker_Navigation_Routing_Component();
 		$patterns  = $instance->get_navigation_route_denylist_patterns();
 		$matched   = null;

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -408,14 +408,18 @@ final class WP_Service_Worker_Navigation_Routing_Component implements WP_Service
 			/**
 			 * Filter list of URL patterns to denylist from handling from the navigation router.
 			 *
+			 * Please note that the pattern is matched against the URL path concatenated with the query string.
+			 * The URL origin (scheme, host, port) are not considered for matching in navigation requests.
+			 *
 			 * @since 0.4
+			 * @link https://github.com/GoogleChrome/workbox/blob/5530e0b5d0b8d4da9f23747ecac665950a26bd51/packages/workbox-routing/src/NavigationRoute.ts#L103-L116
 			 *
 			 * @param array $denylist_patterns Denylist patterns.
 			 */
 			$denylist_patterns = apply_filters( 'wp_service_worker_navigation_route_denylist_patterns', $denylist_patterns );
 
 			// Exclude admin URLs, if not in the admin.
-			$denylist_patterns[] = '^' . preg_quote( untrailingslashit( admin_url() ), '/' ) . '($|\?|/)';
+			$denylist_patterns[] = '^' . preg_quote( untrailingslashit( wp_parse_url( admin_url(), PHP_URL_PATH ) ), '/' ) . '($|\?|/)';
 
 			// Exclude PHP files (e.g. wp-login.php).
 			$denylist_patterns[] = '^[^\?]*?\.php($|\?)';
@@ -433,7 +437,7 @@ final class WP_Service_Worker_Navigation_Routing_Component implements WP_Service
 		}
 
 		// Exclude REST API (this only matters if you directly access the REST API in browser).
-		$denylist_patterns[] = '^' . preg_quote( get_rest_url(), '/' );
+		$denylist_patterns[] = '^' . preg_quote( wp_parse_url( get_rest_url(), PHP_URL_PATH ), '/' );
 
 		return $denylist_patterns;
 	}

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -415,10 +415,10 @@ final class WP_Service_Worker_Navigation_Routing_Component implements WP_Service
 			$denylist_patterns = apply_filters( 'wp_service_worker_navigation_route_denylist_patterns', $denylist_patterns );
 
 			// Exclude admin URLs, if not in the admin.
-			$denylist_patterns[] = '^' . preg_quote( untrailingslashit( wp_parse_url( admin_url(), PHP_URL_PATH ) ), '/' ) . '($|\?|/)';
+			$denylist_patterns[] = '^' . preg_quote( untrailingslashit( admin_url() ), '/' ) . '($|\?|/)';
 
 			// Exclude PHP files (e.g. wp-login.php).
-			$denylist_patterns[] = '[^\?]*?\.php($|\?)';
+			$denylist_patterns[] = '^[^\?]*?\.php($|\?)';
 
 			// Exclude service worker requests (to ease debugging).
 			$denylist_patterns[] = '\?(.*?&)?' . WP_Service_Workers::QUERY_VAR . '=';
@@ -433,7 +433,7 @@ final class WP_Service_Worker_Navigation_Routing_Component implements WP_Service
 		}
 
 		// Exclude REST API (this only matters if you directly access the REST API in browser).
-		$denylist_patterns[] = '^' . preg_quote( wp_parse_url( get_rest_url(), PHP_URL_PATH ), '/' );
+		$denylist_patterns[] = '^' . preg_quote( get_rest_url(), '/' );
 
 		return $denylist_patterns;
 	}

--- a/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
+++ b/wp-includes/components/class-wp-service-worker-navigation-routing-component.php
@@ -415,25 +415,25 @@ final class WP_Service_Worker_Navigation_Routing_Component implements WP_Service
 			$denylist_patterns = apply_filters( 'wp_service_worker_navigation_route_denylist_patterns', $denylist_patterns );
 
 			// Exclude admin URLs, if not in the admin.
-			$denylist_patterns[] = '^' . preg_quote( untrailingslashit( wp_parse_url( admin_url(), PHP_URL_PATH ) ), '/' ) . '($|\?.*|/.*)';
+			$denylist_patterns[] = '^' . preg_quote( untrailingslashit( wp_parse_url( admin_url(), PHP_URL_PATH ) ), '/' ) . '($|\?|/)';
 
 			// Exclude PHP files (e.g. wp-login.php).
-			$denylist_patterns[] = '[^\?]*.\.php($|\?.*)';
+			$denylist_patterns[] = '[^\?]*?\.php($|\?)';
 
 			// Exclude service worker requests (to ease debugging).
-			$denylist_patterns[] = '.*\?(.*&)?(' . join( '|', array( WP_Service_Workers::QUERY_VAR ) ) . ')=';
-			$denylist_patterns[] = '.*/wp\.serviceworker(\?.*)?$';
+			$denylist_patterns[] = '\?(.*?&)?' . WP_Service_Workers::QUERY_VAR . '=';
+			$denylist_patterns[] = '^[^\?]*?\/wp\.serviceworker(\?|$)';
 
 			// Exclude feed requests.
-			$denylist_patterns[] = '[^\?]*\/feed\/(\w+\/)?$';
+			$denylist_patterns[] = '^[^\?]*?\/feed\/(\w+\/)?$';
 
 			// Exclude Customizer preview.
-			$denylist_patterns[] = '\?(.+&)*wp_customize=';
-			$denylist_patterns[] = '\?(.+&)*customize_changeset_uuid=';
+			$denylist_patterns[] = '\?(.*?&)?wp_customize=';
+			$denylist_patterns[] = '\?(.*?&)?customize_changeset_uuid=';
 		}
 
 		// Exclude REST API (this only matters if you directly access the REST API in browser).
-		$denylist_patterns[] = '^' . preg_quote( wp_parse_url( get_rest_url(), PHP_URL_PATH ), '/' ) . '.*';
+		$denylist_patterns[] = '^' . preg_quote( wp_parse_url( get_rest_url(), PHP_URL_PATH ), '/' );
 
 		return $denylist_patterns;
 	}


### PR DESCRIPTION
This fixes an issue reported in a [support topic](https://wordpress.org/support/topic/long-url-with-many-query-parameters-slowing-loading/) where URLs with many query parameters can result in very slow response times by the service worker. Hat tip to @jeffposnick for pointing this out in https://github.com/GoogleChrome/workbox/issues/3077#issuecomment-1119033479.

The regular expressions in question are:

* `/\?(.+&)*wp_customize=/`
* `/\?(.+&)*customize_changeset_uuid=/`

Given this example URL: `https://example.com/?ab=4&v0=56&u0=degrees+Celsius+%28%C2%B0C%29&f0=C&v1=60&u1=degrees+Celsius+%28%C2%B0C%29&f1=C&v2=0.0005&u2=per+degree+Celsius+%28%2F%C2%B0C%29&f2=CdT&v3=100&u3=centimetres+%28cm%29&f3=cm&u4=centimetres+%28cm%29&f4=cm&v5=100&u5=sq+centimetres+%28cm%C2%B2%29&f5=sqcm&v6=100.4&u6=sq+centimetres+%28cm%C2%B2%29&f6=sqcm&v7=100&u7=cu+centimetres+%28cc%2C+cm%C2%B3%29&f7=cucm&v8=100.6&u8=cu+centimetres+%28cc%2C+cm%C2%B3%29&f8=cucm`

The patterns exhibit catastrophic backtracking:

[<img width="699" alt="image" src="https://user-images.githubusercontent.com/134745/167216822-1fb77e27-da8f-4125-b344-3f7364922362.png">](https://regexr.com/6l4qv)

This PR updates the patterns to be more efficient.

Old Pattern | Time
------------|--------------:
`^\/wp\-admin($\|\?.*\|\/.*)`         | 0.2ms
`[^\?]*.\.php($\|\?.*)`              | 0.7ms
`.*\?(.*&)?(wp_service_worker)=`    | 1.1ms
`.*\/wp\.serviceworker(\?.*)?$`     | 0.8ms
`[^\?]*\/feed\/(\w+\/)?$`           | 1.0ms
`\?(.+&)*wp_customize=`             | >250ms
`\?(.+&)*customize_changeset_uuid=` | >250ms
`^\/wp\-json\/.*`                   | 0.1ms

New Pattern | Time
-------|-------:
`^\/wp\-admin($\|\?\|\/)` | 0.0ms
`^[^\?]*?\.php($\|\?)` | 0.1ms
`\?(.*?&)?wp_service_worker=` | 0.1ms
`^[^\?]*?\/wp\.serviceworker(\?\|$)` | 0.1ms
`^[^\?]*?\/feed\/(\w+\/)?$` | 0.1ms
`\?(.*?&)?wp_customize=` | 0.1ms
`\?(.*?&)?customize_changeset_uuid=` | 0.1ms
`^\/wp\-json\/` | 0.0ms