### PR TITLE
Add id attribute to check network and reload script

### DIFF
--- a/tests/test-template.php
+++ b/tests/test-template.php
@@ -34,7 +34,7 @@ class Test_Template extends TestCase {
 		$actual_script = get_echo( 'wp_service_worker_offline_page_reload' );
 		$this->assertTrue( is_offline() );
 		$this->assertFalse( is_500() );
-		$this->assertStringContainsString( '<script type="module">', $actual_script );
+		$this->assertStringContainsString( '<script id="wp-offline-page-reload" type="module">', $actual_script );
 		$this->assertStringContainsString( 'await fetch', $actual_script );
 
 		// Check if script is added when 500.
@@ -44,7 +44,7 @@ class Test_Template extends TestCase {
 		$actual_script = get_echo( 'wp_service_worker_offline_page_reload' );
 		$this->assertFalse( is_offline() );
 		$this->assertTrue( is_500() );
-		$this->assertStringContainsString( '<script type="module">', $actual_script );
+		$this->assertStringContainsString( '<script id="wp-offline-page-reload" type="module">', $actual_script );
 		$this->assertStringContainsString( 'await fetch', $actual_script );
 	}
 }

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -184,7 +184,7 @@ function wp_service_worker_offline_page_reload() {
 
 	?>
 	<script id="wp-navigation-request-properties" type="application/json">{{{WP_NAVIGATION_REQUEST_PROPERTIES}}}</script><?php // phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
-	<script id="check-network-and-reload" type="module">
+	<script id="wp-offline-page-reload" type="module">
 		const shouldRetry = () => {
 			if (
 				new URLSearchParams(location.search.substring(1)).has(

--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -184,7 +184,7 @@ function wp_service_worker_offline_page_reload() {
 
 	?>
 	<script id="wp-navigation-request-properties" type="application/json">{{{WP_NAVIGATION_REQUEST_PROPERTIES}}}</script><?php // phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
-	<script type="module">
+	<script id="check-network-and-reload" type="module">
 		const shouldRetry = () => {
 			if (
 				new URLSearchParams(location.search.substring(1)).has(


### PR DESCRIPTION
While working on https://github.com/ampproject/amp-wp/issues/7122 I realized that the check network and reload script should have an id attribute that can be consumed later for some use cases related to DOM.