### PR TITLE
Fix PHPStan analysis errors; Update `Build, test & measure` workflow

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           coverage: none
           tools: cs2pr
 
@@ -174,9 +174,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           # phpstan requires PHP 7.1+.
-          php-version: 7.4
+          php-version: '8.0'
           extensions: dom, iconv, json, libxml, zip
-          tools: phpstan
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -195,8 +194,8 @@ jobs:
 
       - name: Static Analysis (PHPStan)
         run: |
-          phpstan --version
-          phpstan analyse
+          vendor/bin/phpstan --version
+          vendor/bin/phpstan
 
   #-----------------------------------------------------------------------------------------------------------------------
 

--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -58,9 +58,9 @@ jobs:
           echo "Changed PHP file count: $PHP_FILE_COUNT"
           echo "Changed JS file count: $JS_FILE_COUNT"
 
-          echo "::set-output name=count::$FILE_COUNT"
-          echo "::set-output name=php-count::$PHP_FILE_COUNT"
-          echo "::set-output name=js-count::$JS_FILE_COUNT"
+          echo "count=$FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "php-count=$PHP_FILE_COUNT" >> $GITHUB_OUTPUT
+          echo "js-count=$JS_FILE_COUNT" >> $GITHUB_OUTPUT
         env:
           # Ignore Paths:
           # - .github/
@@ -137,7 +137,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Configure Composer cache
         uses: actions/cache@v3
@@ -179,7 +179,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Configure Composer cache
         uses: actions/cache@v3
@@ -280,7 +280,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Configure Composer cache
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.zip
 /wp-includes/js/workbox*
 /wiki
+.vscode
 
 # Generated via bin/transform-readme.php
 /readme.txt

--- a/wp-includes/class-wp-customize-manager.php
+++ b/wp-includes/class-wp-customize-manager.php
@@ -25,7 +25,6 @@ function pwa_customize_register_site_icon_maskable( WP_Customize_Manager $wp_cus
 		array(
 			'capability' => 'manage_options',
 			'type'       => 'option',
-			'default'    => false,
 			'transport'  => 'postMessage',
 		)
 	);


### PR DESCRIPTION
- Remove `default` arg for `site_icon_maskable` customizer setting. This setting is checkbox hence default value as bool not required.
- Update lint and static analysis jobs to use PHP 8.0
- Update deprecated `::set-output` to use `$GiTHUB_OUTPUT`.